### PR TITLE
plan: add /switchboard-remote orientation skill for Claude web sessions

### DIFF
--- a/.switchboard/plans/add-switchboard-remote-skill.md
+++ b/.switchboard/plans/add-switchboard-remote-skill.md
@@ -1,0 +1,102 @@
+# Add /switchboard-remote Orientation Skill for Claude Web Sessions
+
+## Goal
+
+Create a `/switchboard-remote` skill that orients Claude at the start of a web session on how to use the Linear Remote Control feature as a Switchboard control surface.
+
+### Problem & Background
+
+Switchboard's Linear Remote Control feature allows driving the Kanban board from any Linear client — moving a Linear issue between states dispatches the corresponding local Kanban column agent; comments are routed to the current column's agent. This makes Linear an async message bus between the remote world and the local machine, requiring no SSH or cloud session.
+
+Three control surfaces exist:
+1. **Linear app** — user moves cards manually, limited to status transitions
+2. **Claude.ai web + Linear MCP** — Claude reads the repo (via GitHub MCP), writes rich implementation plans into Linear issue descriptions, and triggers execution via status changes
+3. **Linear native agents** — natural language, but no code analysis capability
+
+Surface #2 is the highest-value option for web sessions because Claude can analyse the codebase and author thorough plans before anything runs locally. The gap is that neither Claude nor users have a concise orientation document explaining this workflow — the information exists only in the README and how-to guide, not as an invocable skill.
+
+---
+
+## Implementation Tasks
+
+### 1. Read source documentation
+Before authoring the skill, the implementer must read:
+- `README.md` §"Linear Remote Control" (line 166–167)
+- `README.md` §"ClickUp & Linear Sync" (lines 145–152)
+- `README.md` §"Live Sync Mode" (lines 169–172)
+- `docs/how_to_use_switchboard.md` §"4. Automated Triage & Remote Control → Linear Remote Control" (lines 69–71)
+
+### 2. Create skill file
+
+**Path:** `.claude/skills/switchboard-remote/SKILL.md`
+
+**Required content sections:**
+
+**Frontmatter**
+```
+---
+name: switchboard-remote
+description: Orient Claude on using Linear MCP as a remote control surface for Switchboard
+---
+```
+
+**Architecture overview**
+- Linear is a two-way sync message bus: Switchboard polls Linear every 30–120s (configurable) and mirrors state changes locally
+- Moving a Linear issue to a new state → dispatches the Kanban column agent for that state on the local machine
+- Comments posted on a Linear issue → routed to the current column's agent as input
+- Plan content lives in the issue description; no special format is required — the dispatched agent reads whatever is there
+- Config is stored in the Kanban DB under key `remote.config`, not in `settings.json`; toggle is in the toolbar remote control button; configuration is in the Kanban REMOTE tab (board selection, ping mode: manual/constant, frequency: 30–120s)
+
+**The three control surfaces** (brief table or list)
+Surface #2 note: Claude's value here is reading the repo via GitHub MCP, writing a detailed implementation plan into the issue description, and setting the trigger status — giving the local agent far richer instructions than a manually written Linear ticket.
+
+**Linear MCP workflow for Claude**
+Step-by-step orientation:
+1. Use `list_projects` / `list_teams` to locate the synced Switchboard project
+2. Use `list_issues` to find the target issue (or `save_issue` to create one)
+3. Use `list_issue_statuses` to identify the status name that triggers local execution
+4. Read the repo / analyze code as needed (GitHub MCP)
+5. Write the implementation plan into the issue description via `save_issue`
+6. Set the trigger status via `save_issue` to dispatch the local agent
+7. On a future session: use `get_issue` to read results written back by the local agent
+
+**Configuration pre-flight**
+Remind Claude to confirm remote control is enabled (toolbar button) and the correct board is mapped in the REMOTE tab before attempting to trigger via status change.
+
+**Reference links**
+- `README.md` §"Linear Remote Control"
+- `README.md` §"ClickUp & Linear Sync"
+- `docs/how_to_use_switchboard.md` §"Automated Triage & Remote Control"
+
+### 3. Register the skill in CLAUDE.md
+
+Add a row to the `### 📚 Available Skills` table:
+
+```
+| `switchboard_remote` | Orient Claude on using Linear MCP as a remote control for Switchboard — use at session start when working from Claude.ai web |
+```
+
+---
+
+## Edge Cases & Risks
+
+- **Remote not enabled:** The skill should remind Claude to verify the remote toggle is on and the board is mapped before attempting status-driven dispatch. A status change on an unmapped board is a no-op.
+- **Status name mismatch:** Linear status names must match what Switchboard expects. The skill should instruct Claude to use `list_issue_statuses` rather than guessing names.
+- **Multiple boards:** If the user has multiple Switchboard boards synced to Linear, Claude needs to identify the right project. The skill should guide using `list_projects` first.
+- **Plan format:** The local agent reads whatever is in the description — no special format is enforced — but the skill should recommend using the standard Switchboard plan structure (Goal, Tasks, etc.) for consistency with local plans.
+- **Read-back latency:** Results written by the local agent appear in the Linear issue after the next Kanban → Linear sync cycle (up to 30s). Claude should note this when checking results in a follow-up session.
+
+---
+
+## Out of Scope
+
+- No changes to the Switchboard extension backend
+- No changes to the Linear sync logic
+- No new UI or configuration options
+
+---
+
+## Metadata
+
+**Complexity:** 2
+**Tags:** docs, cli, infrastructure

--- a/.switchboard/plans/linear-free-tier-auto-archive-on-completion.md
+++ b/.switchboard/plans/linear-free-tier-auto-archive-on-completion.md
@@ -1,0 +1,102 @@
+# Linear Free-Tier: Auto-Archive Issues on Plan Completion
+
+## Goal
+
+Automatically archive Linear issues when their corresponding Switchboard plan reaches the "Code Reviewed" or "Done" column, keeping the active issue count below the free tier's 250-issue hard limit. Add a toggle in the Linear setup panel (default: ON) and surface a clear warning about the limit.
+
+### Background & Problem
+
+Linear's free tier caps active (non-archived) issues at 250. The current Switchboard Linear integration syncs all plans as active issues indefinitely — completed and code-reviewed plans remain active in Linear, burning through the quota. Without auto-archiving, users with active boards will silently hit the cap, causing new plan syncs to fail or behave unexpectedly.
+
+Switchboard already has `LinearSyncService.archiveIssue()` (lines 1528–1560) and a `deleteSyncEnabled` flag for archiving on plan deletion. The gap is a separate, status-triggered archive path for completed plans, and user awareness of the limit.
+
+---
+
+## Implementation Tasks
+
+### 1. Extend `LinearConfig` with archive-on-completion flag
+
+**File:** `src/services/LinearSyncService.ts`, `LinearConfig` interface (lines 17–34)
+
+Add field:
+```typescript
+completionArchiveEnabled: boolean; // default true
+```
+
+Update `loadConfig()` to default `completionArchiveEnabled` to `true` for existing installs where the key is absent (forward-compat default — safe to apply, no destructive effect on data).
+
+### 2. Trigger archive on column transition to completion columns
+
+**File:** `src/services/LinearSyncService.ts` (or the call site in `TaskViewerProvider.ts` that pushes status changes to Linear)
+
+When a plan's Kanban column changes and Linear sync is active:
+- If the new column name is `"Done"` or `"Code Reviewed"` (case-insensitive match)
+- And `LinearConfig.completionArchiveEnabled === true`
+- And the plan has a `linearIssueId`
+- Call `archiveIssue(linearIssueId)`
+
+Do not fail the local column transition if archiving fails — log the error, surface a non-blocking notification ("Could not archive Linear issue — check your Linear API token"), and continue.
+
+**Important:** This should fire on the sync push that writes the new status to Linear, not as a separate polling pass. The archive call replaces no existing logic — it's additive.
+
+### 3. Define completion columns
+
+Completion columns should be resolved from the `columnToStateId` mapping rather than hardcoded strings where possible. As a practical fallback, match against the canonical names `"Done"` and `"Code Reviewed"` case-insensitively. Do not archive for intermediate columns (In Progress, Review, etc.).
+
+If the user has renamed their completion columns to non-standard names, they will not be auto-archived — this is acceptable behaviour for v1. Document this in the setup UI tooltip.
+
+### 4. Add warning note and toggle to setup.html
+
+**File:** `src/webview/setup.html`, Linear section (lines 972–1161, `id="linear-fields"`)
+
+**Warning note** — add near the top of the Linear sync options, visually distinct (amber/yellow left-border callout, not an error):
+```
+⚠ Linear free tier limit: 250 active issues. Completed and code-reviewed plans are 
+archived automatically to stay within this limit. Upgrade your Linear plan or disable 
+auto-archive below if you are on a paid tier.
+```
+
+**Toggle checkbox** — add in the automation/sync options area (near the existing `deleteSyncEnabled` checkbox at lines 1139–1143):
+- Label: **"Archive Linear issues when plans are completed or code reviewed"**
+- Sub-label: *"Recommended for free-tier Linear accounts (250 active issue limit)."*
+- Default: checked (ON)
+- ID: `#linear-completion-archive-checkbox`
+- On change: save to `LinearConfig.completionArchiveEnabled` via existing config save path
+
+### 5. Persist the toggle value
+
+**File:** `TaskViewerProvider.ts` (Linear config save handler, near lines 4756 and 4795)
+
+When saving Linear config from the setup panel, read `#linear-completion-archive-checkbox` state and write `completionArchiveEnabled` to `LinearConfig` in the DB. Ensure it is included in the config reset/fresh-setup path, defaulting to `true`.
+
+---
+
+## Edge Cases & Risks
+
+- **Existing installs:** `completionArchiveEnabled` will be absent in existing `LinearConfig` records. Defaulting to `true` in `loadConfig()` means auto-archive activates on first load after upgrade. This is the right behaviour — existing users are the most likely to have accumulated 250+ issues.
+- **Archive fails silently:** Linear API errors during archive should not block local state transitions. Log and notify non-blockingly.
+- **Already archived:** Calling `archiveIssue()` on an already-archived issue should be a no-op. Verify `archiveIssue()` handles this gracefully (check existing implementation at lines 1528–1560).
+- **Paid tier users:** Users on paid Linear plans have no active issue cap. The toggle (default ON) is harmless for them but may clutter their Linear history. The warning note should acknowledge this and make it easy to disable.
+- **Column name mismatches:** If completion columns are renamed, auto-archive won't fire. The setup UI tooltip should mention this so users know to check.
+- **Race with deleteSyncEnabled:** If a plan is deleted from Switchboard, `deleteSyncEnabled` may also try to archive. This is a no-op double-archive — safe.
+
+---
+
+## Migration
+
+No schema changes. `LinearConfig` is stored as a JSON blob in the Kanban DB config table. Adding a new key with a default in `loadConfig()` is a non-destructive migration.
+
+---
+
+## Out of Scope
+
+- No change to what "archive" means in Linear (uses existing `archiveIssue()` GraphQL mutation)
+- No configurable list of completion column names (v1: canonical names only)
+- No retroactive archiving of already-completed plans on upgrade (only new transitions trigger it)
+
+---
+
+## Metadata
+
+**Complexity:** 3
+**Tags:** backend, api, ui, reliability, infrastructure

--- a/.switchboard/plans/linear-remote-agent-skill-copy-button.md
+++ b/.switchboard/plans/linear-remote-agent-skill-copy-button.md
@@ -1,0 +1,101 @@
+# Linear Remote Tab: Dynamic Agent Skill Copy Button
+
+## Goal
+
+Add a "Copy Linear Agent Skill" button to the Kanban REMOTE tab that generates a tailored instruction text for the Linear native agent, pre-filled with the user's actual board/status mappings. The user pastes this into Linear's agent configuration manually as a one-time setup step.
+
+### Background & Problem
+
+Switchboard's Linear Remote Control feature allows driving the Kanban board from any Linear client — moving an issue between Linear states dispatches the local column agent; comments are routed to that agent and responses written back. The Linear app has a native AI agent that users can instruct to manage issues on their behalf. However, for the native agent to operate correctly as a Switchboard controller, it needs to know:
+- Which Linear status names map to which Switchboard actions
+- How to format issue descriptions as plans
+- How to interact via comments
+
+There is currently no way for Switchboard to surface this information in a usable form. Users must manually piece together their own instructions from documentation. Because the sync function ensures Linear status names match Switchboard column names, the mapping data is already in the DB and can be used to generate a fully tailored skill text with zero user effort.
+
+---
+
+## Implementation Tasks
+
+### 1. Read column-to-state mapping for skill generation
+
+**File:** `src/services/LinearSyncService.ts`
+
+The `LinearConfig` interface (lines 17–34) contains `columnToStateId: Record<string, string>` — a map of Switchboard column names to Linear state IDs. The state names and column names match by convention (enforced by the sync function). This is loaded via `loadConfig()` from the Kanban DB config table under key `"linear-config"`.
+
+The skill generator needs:
+- Column names from `columnToStateId` keys (these ARE the Linear status names)
+- Remote config from DB key `"remote.config"` for any board-level context
+
+### 2. Implement skill text generator
+
+Add a function (in the kanban webview message handler or a utility in `LinearSyncService.ts`) that:
+
+1. Loads `LinearConfig.columnToStateId` to extract column/status names
+2. Identifies which columns represent "trigger" states (all mapped columns)
+3. Interpolates into a template:
+
+```
+You are a controller for the Switchboard AI development board.
+
+## How it works
+Switchboard polls Linear every [ping frequency]s. When you move an issue to a new state, it dispatches the corresponding local AI agent. Comments you post on an issue are routed to that column's agent; responses appear as new comments.
+
+## Column → Agent mapping
+[For each column name in the mapping:]
+- Move to "[Column Name]" → dispatches the [Column Name] agent
+
+## How to write plans
+Place the implementation plan in the issue description. No special format is required, but use clear sections (Goal, Tasks, Notes). The local agent reads whatever is in the description.
+
+## Responding to questions
+If the user asks a question in a comment, post it as a comment on the issue. The local agent will respond in a follow-up comment within one polling cycle.
+
+## Setup notes
+- Remote control must be enabled (toolbar button in VS Code).
+- Only move issues between states that appear in the mapping above.
+- Do not create new Linear states — only use the ones listed.
+```
+
+### 3. Add "Copy Linear Agent Skill" button to REMOTE tab
+
+**File:** `src/webview/kanban.html`, REMOTE tab section (lines 2544–2593, `#remote-tab-content`)
+
+- Add a button below the existing remote description text, labelled **"Copy Linear Agent Skill"**
+- On click: generate the skill text (using current config from DB), write to clipboard, show brief "Copied!" feedback on the button (revert after 2s)
+- Disable the button (with tooltip "Configure Linear sync first") if `columnToStateId` is empty or remote control is not configured
+
+### 4. Wire up the message handler
+
+**File:** `src/webview/kanban.html` JS section (lines 6879–6957)
+
+Add a `vscode.postMessage` call for the button click, and a handler in the extension host (`TaskViewerProvider.ts` or equivalent) that:
+1. Loads `LinearConfig` via `LinearSyncService.loadConfig()`
+2. Loads `remote.config` from DB
+3. Generates the skill text
+4. Posts it back to the webview
+5. Webview writes to clipboard via `navigator.clipboard.writeText()`
+
+---
+
+## Edge Cases & Risks
+
+- **No mapping configured:** If `columnToStateId` is empty (Linear not set up), the button should be disabled with a clear label explaining why.
+- **Partial mapping:** Some columns may not be mapped to Linear states. Only include mapped columns in the generated text — don't reference unmapped ones.
+- **Ping frequency:** Read from `remote.config` to interpolate the actual polling interval. Default to "60s" if not set.
+- **Clipboard API availability:** `navigator.clipboard` requires a secure context. The webview runs in VS Code's sandboxed iframe — use the standard clipboard API; if it fails, fall back to a textarea + `document.execCommand('copy')`.
+
+---
+
+## Out of Scope
+
+- No changes to the Linear sync protocol
+- No changes to how remote control works
+- No automated posting of the skill text to Linear
+
+---
+
+## Metadata
+
+**Complexity:** 3
+**Tags:** frontend, backend, api, ui, infrastructure


### PR DESCRIPTION
Documents the plan to create a Claude skill that orients web sessions on
using Linear MCP as a remote control surface for Switchboard.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018nmKteGNwWGoBxwyCVZZs9