### PR TITLE
Add planning session plans: Linear bidirectional sync and channel issues

### DIFF
--- a/.switchboard/plans/linear-bidirectional-description-sync.md
+++ b/.switchboard/plans/linear-bidirectional-description-sync.md
@@ -1,0 +1,100 @@
+# Linear Bidirectional Description Sync
+
+## Goal
+
+Make the Linear ↔ Switchboard body/content sync genuinely bidirectional. Currently plan edits push to Linear (via ContinuousSyncService) but Linear description changes are never pulled back — the inbound path only fires when *both* sides changed (conflict dialog). Users who draft or refine plan content in Linear expect it to appear in Switchboard automatically.
+
+## Dependencies
+
+None — builds on existing ContinuousSyncService and RemoteControlService infrastructure.
+
+## Problem Analysis
+
+### Current State: Outbound Only
+
+ContinuousSyncService watches local plan files for changes, debounces 3 seconds (max 60s), and pushes the content to the linked Linear issue description via `issueUpdate` mutation. This works well.
+
+The inbound direction is broken for the common case: `_detectExternalConflict()` in ContinuousSyncService fetches the Linear description but only acts when *both* sides changed. If the user edits in Linear and the local file is untouched, no conflict is detected and the change is silently ignored.
+
+### Root Cause: No Persisted Sync Timestamp Per Issue
+
+`lastSyncAt` in `LiveSyncState` is in-memory only — lost on every extension reload. `fetchIssueUpdates()` in LinearSyncService doesn't fetch `updatedAt` or `description` from Linear, so the remote control poll has no way to detect description changes. There is no persisted "last synced at" per issue to compare against.
+
+### Design: Last-Writer-Wins via Timestamps
+
+On each remote control poll cycle:
+- If `issue.updatedAt > persistedCursor` and local file mtime ≤ cursor → **pull** (Linear is newer, local unchanged)
+- If `issue.updatedAt > persistedCursor` and local file mtime > cursor → **conflict** (both changed)
+- If `issue.updatedAt ≤ cursor` → skip
+
+When ContinuousSyncService pushes to Linear, persist the cursor for that issue so the next poll doesn't re-pull the same content.
+
+Loop prevention: when RemoteControlService writes pulled content to disk, ContinuousSyncService's file watcher fires and would re-push. Guard: before pushing, compare `hash(strippedContent)` against a `markExternallyWritten` hash. If they match, skip the push.
+
+## Implementation
+
+### 1. Extend `fetchIssueUpdates()` — `src/services/LinearSyncService.ts`
+
+Add `updatedAt` and `description` to the GraphQL query and return type. Currently only `state` and `comments` are fetched.
+
+### 2. Persist description-sync cursors — `src/services/KanbanProvider.ts`
+
+Add two methods mirroring the existing `remote.commentCursors` pattern in the DB config table:
+- `getDescriptionCursors(): Promise<Record<string, string>>` — reads `remote.descriptionSyncedAt`
+- `setDescriptionCursor(issueId: string, timestamp: string): Promise<void>`
+
+### 3. Pull path — `src/services/RemoteControlService.ts`
+
+After existing state-mirror and comment-ingestion steps in `_poll()`, add `_ingestDescription()`:
+
+```
+for each card in poll batch:
+  cursor = descriptionCursors[issueId] ?? epoch
+  if issue.updatedAt <= cursor → skip
+  GRACE_MS = 5000
+  if localFileMtime > Date(cursor) + GRACE_MS → CONFLICT: notify, skip
+  else → PULL:
+    read plan file, preserve H1 title
+    replace body with issue.description
+    write file
+    call onDescriptionPulled(issueId, hash(newContent))
+    setDescriptionCursor(issueId, issue.updatedAt)
+```
+
+Inject into RemoteControlService constructor:
+- `getDescriptionCursors`, `setDescriptionCursor` from KanbanProvider
+- `onDescriptionPulled: (issueId, contentHash) => void`
+
+### 4. Loop prevention — `src/services/ContinuousSyncService.ts`
+
+- Add `_externallyWrittenHashes: Map<string, string>` (in-memory)
+- Add `markExternallyWritten(issueId, hash)` — stores hash; called via `onDescriptionPulled` callback
+- In push path: if `hash(strippedContent) === _externallyWrittenHashes.get(issueId)` → skip push, clear entry
+- On successful push: call `onDescriptionSynced(issueId, new Date().toISOString())` → persists cursor
+
+### 5. Wire up — `src/services/KanbanProvider.ts`
+
+```typescript
+remoteControl = new RemoteControlService({
+  ...existingDeps,
+  getDescriptionCursors: () => this._getDescriptionCursors(),
+  setDescriptionCursor: (id, ts) => this._setDescriptionCursor(id, ts),
+  onDescriptionPulled: (issueId, hash) =>
+    continuousSyncService?.markExternallyWritten(issueId, hash),
+})
+
+continuousSyncService = new ContinuousSyncService({
+  ...existingDeps,
+  onDescriptionSynced: (issueId, ts) => this._setDescriptionCursor(issueId, ts),
+})
+```
+
+## Verification
+
+1. **Push path unchanged**: Edit plan locally → ContinuousSyncService pushes → cursor persisted → next poll skips (updatedAt == cursor).
+2. **Pull path**: Edit Linear issue description, leave local file untouched → next poll detects change → description written to plan file → no re-push (hash guard).
+3. **Conflict path**: Edit both sides between polls → conflict notification shown, no auto-overwrite.
+4. **Loop prevention**: After pull, file watcher fires → ContinuousSyncService hash guard triggers → push skipped → no updatedAt bump in Linear → next poll is a no-op.
+5. **Reload safety**: Restart extension → cursors loaded from DB → no false positives.
+
+Run: `src/test/integrations/linear/linear-sync-service.test.js`, `linear-import-flow.test.js`. Add unit tests for `_ingestDescription()` covering pull, skip, and conflict branches.

--- a/.switchboard/plans/linear-channel-issues-analyst-and-command.md
+++ b/.switchboard/plans/linear-channel-issues-analyst-and-command.md
@@ -1,0 +1,110 @@
+# Linear Channel Issues: Analyst Chat & Extension Command Interface
+
+## Goal
+
+Introduce **Linear channel issues** — designated Linear issues that act as persistent named channels rather than plan-linked issues. Two initial channel types:
+
+1. **Analyst channel** — comments route directly to the analyst terminal (no plan file, no column agent). The analyst replies back as a comment on the same issue, making it a two-way chat thread in Linear.
+2. **Command channel** — comments are parsed as extension commands (`open kanban`, `create terminal <role>`, `dispatch <plan> <role>`, `status`). The extension executes them and posts an ack reply.
+
+## Dependencies
+
+None — builds on existing RemoteControlService poll infrastructure and analyst terminal dispatch.
+
+## Problem Analysis
+
+### Current State: All Comments Are Plan-Scoped
+
+`RemoteControlService._ingestComments()` only processes comments on plan-linked issues. Every comment is appended to a plan file and dispatched to the plan's current column agent. There is no way to send a message directly to the analyst terminal from Linear, and no way to trigger extension-level actions remotely.
+
+### Design: Channel Issues Polled Alongside Plan Issues
+
+Channel issues are stored by ID in `linear-config.json`. During each remote control poll cycle, they are fetched alongside plan issues using the same `fetchIssueUpdates()` call and the same `commentCursors` mechanism for deduplication. Comments on channel issues never touch plan files — they route to dedicated handlers.
+
+The existing `REMOTE_MODE_DIRECTIVE` in `agentPromptBuilder.ts` already instructs agents to post results as Linear comments when under remote control. The analyst channel reuses this: no additional write-back plumbing is needed — the analyst receives the message and knows to reply via `linear_api` skill.
+
+Self-comment loops are prevented by the existing `hasMarker()` guard on outbound comments.
+
+## Implementation
+
+### 1. Config schema — `src/services/LinearSyncService.ts` + `linear-config.json`
+
+Add to the Linear config type:
+```typescript
+analystChannelIssueId?: string;
+commandChannelIssueId?: string;
+```
+Persist in `linear-config.json` via the existing `loadConfig()` / `saveConfig()` pattern.
+
+### 2. REMOTE tab UI — `src/webview/kanban.html`
+
+Add a "Channel Issues" section to the REMOTE tab (below existing board-sync config):
+
+- **Analyst channel**: text input for Linear issue URL or ID + "Auto-create" button (creates a Linear issue titled "Switchboard Analyst Channel", stores its ID).
+- **Command channel**: same pattern.
+- Status indicator per channel (green = configured, grey = not set).
+
+Webview → extension message: `{ type: 'saveChannelConfig', analystChannelIssueId, commandChannelIssueId }` → `LinearSyncService.saveConfig()`.
+
+### 3. Poll channel issues — `src/services/RemoteControlService.ts`
+
+After the existing plan-issue batch in `_poll()`, call new `_pollChannelIssues()`:
+1. Load channel IDs from config; skip if not set.
+2. Call `LinearSyncService.fetchIssueUpdates([analystId, commandId])` (same method).
+3. Filter new comments via existing `commentCursors` keyed by channel issue ID.
+4. Skip `hasMarker()` comments (self-comment guard).
+5. Route: analyst ID → `_handleAnalystChannelComment()`; command ID → `_handleCommandChannelComment()`.
+
+### 4. Analyst channel handler — `src/services/RemoteControlService.ts`
+
+New `_handleAnalystChannelComment(comment)`:
+1. Format: `## Linear Message (ISO timestamp)\n\n{comment.body}\n\n[Post your response as a comment on this Linear issue via linear_api skill]`
+2. Call injected `sendToAnalyst(formattedMessage)`.
+3. Advance cursor for analyst channel issue.
+
+Inject: `sendToAnalyst: (msg: string) => Promise<void>`
+Provided by `KanbanProvider` calling `TaskViewerProvider._handleSendAnalystMessage()`.
+
+### 5. Command channel handler — `src/services/RemoteControlService.ts`
+
+New `_handleCommandChannelComment(comment)`:
+
+Parse comment body (lowercase, trim) against command table:
+
+| Comment | Action |
+|---|---|
+| `open kanban` | `vscode.commands.executeCommand('switchboard.openKanban')` |
+| `status` | Build summary of open plans per column, reply as comment |
+| `create terminal <role>` | Create VS Code terminal for named role |
+| `dispatch <plan-substring> <role>` | Find matching plan, dispatch to role |
+| `context map <plan-substring>` | Trigger analyst context map for plan |
+
+Post reply on command channel issue via `LinearSyncService.addComment(issueId, resultText + hasMarker())`.
+
+On unknown command, reply: `Unknown command: "<text>". Available: open kanban, status, dispatch <plan> <role>, create terminal <role>, context map <plan>`.
+
+Advance cursor.
+
+Inject: `executeCommand: (verb: string, args: string[]) => Promise<string>`
+Provided by `KanbanProvider._executeChannelCommand()`.
+
+### 6. Wire up — `src/services/KanbanProvider.ts`
+
+In `_getRemoteControl()`, pass new deps:
+```typescript
+sendToAnalyst: async (msg) =>
+  this._taskViewerProvider?._handleSendAnalystMessage(msg),
+executeCommand: async (verb, args) =>
+  this._executeChannelCommand(verb, args),
+```
+
+Add `_executeChannelCommand(verb, args)` — switch on verb, calls appropriate `vscode.commands.executeCommand(...)` or internal method, returns result string.
+
+## Verification
+
+1. **Analyst channel**: Configure issue ID in REMOTE tab → post comment in Linear → next poll picks it up → analyst terminal receives formatted message → analyst posts reply comment on same issue.
+2. **Command channel**: Post `status` → extension replies with board summary. Post `open kanban` → kanban panel opens.
+3. **No cross-contamination**: Plan-issue comments still route to plan agents; channel comments never appear in plan files.
+4. **Self-comment guard**: Extension reply comments (marked with `hasMarker()`) are not re-ingested on next poll.
+5. **Cursor persistence**: Restart extension → channel cursors loaded from DB → no re-processing of old comments.
+6. **Auto-create**: Click "Auto-create" for analyst channel → new Linear issue created → ID saved → status indicator turns green.


### PR DESCRIPTION
- linear-bidirectional-description-sync.md: last-writer-wins body sync
  between Linear issue descriptions and local plan files, using persisted
  cursors and a hash-based loop prevention guard in ContinuousSyncService
- linear-channel-issues-analyst-and-command.md: dedicated Linear issues
  as named channels — analyst chat thread and extension command interface

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013UaUFmnVd9SLm4ACd6Fcj3