### PR TITLE
Add remote planning infrastructure epic and child plans

### DIFF
--- a/.switchboard/plans/epic-remote-planning-infrastructure.md
+++ b/.switchboard/plans/epic-remote-planning-infrastructure.md
@@ -1,0 +1,56 @@
+# Epic: Remote Planning Infrastructure
+
+## Goal
+
+Enable full Switchboard planning workflows from remote sessions (Claude Code on the web, claude.ai) without requiring the local machine or IDE to be running. Plans are read from and written directly to Linear/Notion via MCP — no git branches, no pull requests, no repo file writes for the planning phase.
+
+### Problem & Background
+
+Currently Switchboard plans are `.md` files in `.switchboard/plans/`. All column transitions are executed by the Switchboard VS Code extension on the local machine. This creates two blockers for remote sessions:
+
+1. **Branch/git dependency**: A remote agent (Claude Code web) must commit plan files to a branch and open a PR. The user must pull and review before any work lands in the kanban board.
+2. **No async column transitions**: If a remote agent improves a plan and wants to advance the kanban card, the extension must be running. Without it, the card stays stuck in its current column until the user manually moves it.
+
+The fix is to make Linear/Notion the source of truth for plans during the remote phase, using the existing two-way sync infrastructure. The extension already maps Linear statuses to kanban columns — so a remote agent updating a Linear issue status is equivalent to moving a kanban card, picked up on next IDE startup via a new reconciliation step.
+
+---
+
+## Phase 1 — Remote Plan Improvement (no git)
+
+**Goal**: A remote agent can improve plans and advance kanban columns entirely via Linear/Notion MCP, with no git involvement.
+
+**Child plans:**
+- `improve-remote-plan-skill.md` — New `/improve-remote-plan` skill: reads plan from Linear/Notion, applies improve-plan logic, writes content and status back via MCP
+- `sw-remote-entry-skill.md` — New `/sw-remote` skill: entry point for remote sessions, orients agent to remote-mode workflow (supersedes `add-switchboard-remote-skill.md`)
+- `kanban-startup-reconciler.md` — Extension feature: on startup, query Linear/Notion for status changes made during offline period and reconcile kanban.db
+
+**Dependency**: Phase 1 requires the Linear/Notion remote control to already be configured and a board mapped. No new sync infrastructure needed.
+
+---
+
+## Phase 2 — Repo Mapping & Live Doc Sync
+
+**Goal**: Detailed codebase documentation lives in Linear/Notion, maintained continuously by the extension. Enables pure claude.ai + Notion connector planning sessions with no Claude Code remote, no GitHub MCP, no branches.
+
+**Child plans:** TBD — requires a design session on:
+- Rate limit management for continuous sync (Notion: ~3 req/s, Linear: similar)
+- Doc granularity strategy (file summaries, module docs, ADRs)
+- Leveraging existing notebooklm integration folder as a base
+- Sync state tracking (what changed, what was already pushed)
+
+**Outcome**: User opens claude.ai, attaches Notion, asks Claude to write a plan. Claude reads live codebase docs from Notion, authors a plan, writes it back to Notion with the trigger status. Extension picks it up on startup. Zero git.
+
+---
+
+## Out of Scope (this epic)
+
+- Changes to the existing `/sw` (switchboard-chat) skill — it remains for users without remote integration
+- ClickUp support in Phase 1 (Linear/Notion only, ClickUp can follow)
+- Automated plan creation from scratch remotely (Phase 1 covers improvement only)
+
+---
+
+## Metadata
+
+**Complexity:** 7
+**Tags:** infrastructure, backend, cli, feature, devops

--- a/.switchboard/plans/improve-remote-plan-skill.md
+++ b/.switchboard/plans/improve-remote-plan-skill.md
@@ -1,0 +1,95 @@
+# Add /improve-remote-plan Skill for Linear/Notion-Native Plan Improvement
+
+## Goal
+
+Create an `/improve-remote-plan` skill that improves a Switchboard plan living in Linear or Notion — reading content from the issue/page, deepening it with improve-plan logic, writing the result back via MCP, and advancing the card's status — all without touching the git repo or local filesystem.
+
+### Problem & Background
+
+The existing `/improve-plan` workflow reads `.md` plan files from `.switchboard/plans/` and writes back to the same files. In a remote session (Claude Code web, claude.ai) with no local machine running, this creates a git dependency: the agent must commit to a branch and open a PR before any improvement lands in the kanban board. There is also a timing race where the extension starts before the branch is pulled, so column transitions are missed.
+
+The root fix is to treat Linear/Notion as the canonical plan store during the remote phase. The extension's existing two-way sync already maps Linear statuses to kanban columns — so writing content and updating a status in Linear is functionally equivalent to editing the plan file and moving the card, picked up by the startup reconciler (see `kanban-startup-reconciler.md`).
+
+This skill is the agent-side half of that fix.
+
+---
+
+## Implementation Tasks
+
+### 1. Create skill file
+
+**Path:** `.claude/skills/improve-remote-plan/SKILL.md`
+
+**Frontmatter:**
+```
+---
+name: improve-remote-plan
+description: Improve a Switchboard plan stored in Linear or Notion — reads, deepens, and writes back via MCP without touching git
+---
+```
+
+### 2. Skill instruction content
+
+The skill must orient the agent on the following workflow:
+
+**Pre-flight**
+- Confirm Linear or Notion MCP is connected before proceeding
+- If neither is available, abort and tell the user to use `/improve-plan` instead (requires local session)
+- Use `list_issue_statuses` (Linear) or equivalent Notion query to identify the column-trigger status names before writing — never guess
+
+**Read phase**
+- Locate the target plan: accept an issue ID/URL directly, or if none provided, query for issues in the "Created" / backlog status within the Switchboard-mapped project
+- Read the full issue description (Linear: `get_issue`; Notion: read the page body)
+- If description is empty or missing a `## Goal` section, warn the user — the plan may not have been authored yet
+
+**Improve phase**
+Apply the same logic as `/improve-plan`:
+- Sharpen and expand the `## Goal` section with problem analysis and root cause if missing
+- Identify and document edge cases not covered by the current tasks
+- Deepen implementation tasks with specific file paths, method names, and constraints where inferable from the description
+- Add or improve `## Edge Cases & Risks` and `## Out of Scope` sections
+- Do NOT change the plan's intent or introduce scope the user hasn't approved
+
+**Write phase**
+- Write the improved content back to the issue description (Linear: `save_issue`; Notion: update page body)
+- Update the issue status to the "Improved" / next-column trigger state as configured in the remote control mapping
+- Do NOT move the Linear issue to a status that triggers local execution (e.g. "Coded") unless the user explicitly instructs it — the purpose of this skill is improvement, not dispatch
+
+**Confirmation**
+- Report back: issue ID, what was changed (summary), and what status it was set to
+- Remind the user that the kanban card will advance on next IDE startup via the reconciler
+
+### 3. Register the skill in CLAUDE.md
+
+Add a row to the `### 📚 Available Skills` table:
+
+```
+| `improve-remote-plan` | Improve a plan stored in Linear/Notion via MCP — reads, deepens, writes back, and advances status without touching git. Use in remote sessions. |
+```
+
+---
+
+## Edge Cases & Risks
+
+- **No MCP connected**: Skill must detect this and abort gracefully with a clear message
+- **Multiple Switchboard projects in Linear**: Agent must use `list_projects` to identify the correct one, not assume
+- **Status name mismatch**: The "next column" status name must be read from the remote control config, not hardcoded. Incorrect status = silent no-op or wrong column advance
+- **Plan has no content yet**: If the issue description is a stub, the skill should warn rather than silently produce a minimal improvement
+- **Notion vs Linear branch**: The skill should detect which MCP is available and use the appropriate tool calls — don't assume Linear
+- **Reconciler not yet deployed**: If the startup reconciler (see `kanban-startup-reconciler.md`) hasn't been implemented yet, the status update will be written to Linear/Notion but won't advance the kanban card until the user manually moves it. The skill should note this caveat until the reconciler ships.
+
+---
+
+## Out of Scope
+
+- Creating new plans from scratch (read-phase requires existing plan content)
+- Dispatching local execution (that's a separate status transition the user controls)
+- ClickUp support (follow-on)
+- Modifying the `/improve-plan` skill (local session variant stays unchanged)
+
+---
+
+## Metadata
+
+**Complexity:** 3
+**Tags:** cli, infrastructure, feature, docs

--- a/.switchboard/plans/kanban-startup-reconciler.md
+++ b/.switchboard/plans/kanban-startup-reconciler.md
@@ -1,0 +1,84 @@
+# Kanban Startup Reconciler for Remote Plan Status Changes
+
+## Goal
+
+Add a startup reconciliation step to the Switchboard extension that queries Linear/Notion on IDE load, detects plan statuses updated by a remote agent since the last sync, and advances the corresponding kanban cards in `kanban.db` — without requiring a manual card move or a git pull.
+
+### Problem & Background
+
+When a remote agent uses `/improve-remote-plan`, it writes improved content and updates the plan status in Linear/Notion. But the Switchboard extension only processes Linear/Notion status changes in "active polling" mode — which assumes the local machine is running and the user is actively working. When the machine was off, those status changes accumulate unprocessed. On next IDE startup, the extension loads `kanban.db` from disk, which has stale column state — the cards are still in their pre-remote-session column.
+
+There is no timing problem with a startup reconciler (unlike a local `pending-moves.json` file) because the extension queries Linear/Notion directly during startup, not from the filesystem. The remote state is always available regardless of git pull order.
+
+The natural insertion point is `initializeKanbanDbOnStartup()` in `src/services/TaskViewerProvider.ts` (line 2491), which already runs after the kanban DB is loaded and before the webview renders.
+
+---
+
+## Implementation Tasks
+
+### 1. Identify the sync timestamp
+
+The reconciler needs to know what "since last sync" means. Options:
+- Read the `last_remote_sync` timestamp from `kanban.db` config table (key already used by the existing polling sync)
+- Fall back to "last 7 days" if no timestamp exists (covers the case where polling was never run)
+
+Use whichever timestamp the existing polling sync already writes — do not create a new timestamp key unless one doesn't exist.
+
+### 2. Add `reconcileRemoteStatusChanges()` to TaskViewerProvider
+
+**Location:** `src/services/TaskViewerProvider.ts`
+
+**Call site:** At the end of `initializeKanbanDbOnStartup()`, after the existing plan import logic.
+
+**Logic:**
+```
+reconcileRemoteStatusChanges(db, workspaceRoot):
+  1. Check if remote control is configured and enabled for this workspace
+     - Read remote config from kanban.db (key: remote.config)
+     - If not configured or disabled: return immediately (no-op)
+  2. Determine since-timestamp (last_remote_sync or 7-day fallback)
+  3. Query Linear/Notion for issues in the mapped project updated since that timestamp
+     - Use the existing remote control service/client (do not create new API wrappers)
+     - Filter to issues whose status changed (not just description edits)
+  4. For each changed issue:
+     a. Find matching kanban card by Linear issue ID or plan file path stored in the card's metadata
+     b. If found: move card to the column mapped to the new Linear/Notion status
+     c. If not found: log a warning, skip (do not create a new card — that's the file watcher's job)
+  5. Update last_remote_sync timestamp in kanban.db
+  6. Log a summary: "Startup reconciler: N cards advanced from remote status changes"
+```
+
+### 3. Reuse existing remote control client
+
+The extension already has a Linear/Notion client used by the polling sync. The reconciler must use the same client and the same status→column mapping logic — do not duplicate it. Identify the service class handling remote polling (likely in `src/services/` or `src/remote/`) and call it from the reconciler.
+
+### 4. Startup mode flag
+
+The reconciler runs once at startup and then stops. It must not start a polling interval. Add a clear comment distinguishing it from the active polling mode.
+
+---
+
+## Edge Cases & Risks
+
+- **Remote control not configured**: Must be a clean no-op — no error, no warning, just skip
+- **Network unavailable at startup**: Wrap the Linear/Notion query in a try/catch; log the failure but do not block the rest of startup
+- **Card not found for a changed issue**: This can happen if the plan was created remotely and hasn't been imported to kanban.db yet. Log it, skip it — the file watcher or next polling cycle will handle import
+- **Multiple status changes since last sync**: Apply the latest status only (the issue's current state), not intermediate transitions
+- **Timestamp drift**: If the local machine clock differs significantly from Linear/Notion server time, the since-timestamp filter may miss changes. Use a small buffer (e.g. subtract 5 minutes from last_remote_sync)
+- **Rate limits**: The startup query is a single list call per workspace — well within Linear/Notion limits. Do not paginate unnecessarily; limit to recently updated issues
+
+---
+
+## Out of Scope
+
+- Creating new kanban cards for remotely-created plans (handled by the existing file watcher / plan import)
+- Syncing plan content changes back to `.md` files (the remote plan stays in Linear/Notion)
+- ClickUp support (follow-on)
+- Changing the active polling mode
+
+---
+
+## Metadata
+
+**Complexity:** 4
+**Tags:** backend, infrastructure, reliability, feature

--- a/.switchboard/plans/sw-remote-entry-skill.md
+++ b/.switchboard/plans/sw-remote-entry-skill.md
@@ -1,0 +1,93 @@
+# Add /sw-remote Entry Skill for Remote Switchboard Sessions
+
+## Goal
+
+Create a `/sw-remote` skill that serves as the entry point for remote Switchboard planning sessions (Claude Code web, claude.ai). It orients the agent to the remote-mode workflow: plans live in Linear/Notion, MCP is the control surface, git is not used for planning, and `/improve-remote-plan` replaces `/improve-plan`.
+
+### Problem & Background
+
+The existing `/sw` (switchboard-chat) skill assumes the agent can read `.switchboard/plans/`, write plan files, and trigger column transitions — all of which require the local machine and VS Code extension to be active. There is also an existing stub plan `add-switchboard-remote-skill.md` that covers basic Linear orientation, but it only addresses the "dispatch" use case (writing a plan then triggering execution). It does not cover the async improvement workflow or the startup reconciler pattern.
+
+`/sw-remote` is a full peer to `/sw` for remote contexts. It replaces the stub orientation approach with a complete entry-point skill that knows about the remote planning stack. `/sw` is unchanged — it remains the correct entry point for users without remote integration.
+
+---
+
+## Implementation Tasks
+
+### 1. Create skill file
+
+**Path:** `.claude/skills/sw-remote/SKILL.md`
+
+**Frontmatter:**
+```
+---
+name: sw-remote
+description: Entry point for remote Switchboard planning sessions — orients Claude to use Linear/Notion MCP instead of local files
+---
+```
+
+### 2. Skill instruction content
+
+**On invocation**, the skill must:
+
+**1. Confirm remote context**
+- Check which MCP servers are connected (Linear, Notion, GitHub)
+- Report what's available and note any missing connections (e.g., if neither Linear nor Notion is connected, warn the user that remote planning won't be possible)
+
+**2. Orient on remote-mode rules**
+Communicate the following to the agent's working context:
+- Plans are stored in Linear/Notion — do NOT write `.md` files to `.switchboard/plans/` or commit to a branch for planning work
+- Use `list_issues` / Notion queries to read the current kanban state (not local `kanban.db` or `kanban-board.md`)
+- To improve a plan: use `/improve-remote-plan` (not `/improve-plan`)
+- To create a new plan: write directly to a new Linear issue or Notion page, set status to "Created"
+- Column transitions happen via status updates in Linear/Notion — the extension picks them up on next IDE startup
+- To trigger local execution: set the Linear/Notion status to the execution-trigger state (confirm the name with `list_issue_statuses` first)
+
+**3. Read current board state**
+- Query Linear/Notion for issues in the Switchboard-mapped project, grouped by status
+- Present a brief summary: how many plans per column, any plans in a state that suggests remote action is needed (e.g., "Created" plans that could be improved)
+
+**4. Prompt for intent**
+After orientation, ask: "What would you like to work on?" — same consultative opening as `/sw`.
+
+### 3. Register alias in CLAUDE.md
+
+Add `sw-remote` to the Workflow Registry table and the Available Skills table:
+
+**Workflow Registry:**
+```
+| `/sw-remote` | **`sw-remote.md`** | Remote session entry point — Linear/Notion MCP planning mode |
+```
+
+**Available Skills:**
+```
+| `sw-remote` | Entry point for remote Switchboard sessions — orients Claude to Linear/Notion MCP workflow. Use instead of /sw when local machine is off. |
+```
+
+### 4. Supersede the stub plan
+
+Mark `add-switchboard-remote-skill.md` as superseded by this plan. The simpler orientation content it describes can be folded into this skill's architecture overview section.
+
+---
+
+## Edge Cases & Risks
+
+- **Neither Linear nor Notion connected**: Skill should degrade gracefully — explain the limitation and offer to fall back to `/sw` if the user has local access
+- **Multiple boards mapped**: If multiple Switchboard projects exist in Linear, the skill must guide the user to identify the correct one
+- **User accidentally uses `/sw` in a remote session**: Not a hard error, but `/sw` will try to read local files that don't exist. The skill file for `/sw` could add a note pointing to `/sw-remote` for remote contexts
+- **Status name drift**: Linear status names can be renamed by the user. The skill should always use `list_issue_statuses` rather than assuming names from prior sessions
+
+---
+
+## Out of Scope
+
+- Modifying `/sw` (switchboard-chat) — it stays unchanged for local sessions
+- ClickUp support (follow-on after Linear/Notion)
+- Auto-detecting remote vs local context (user explicitly invokes `/sw-remote`)
+
+---
+
+## Metadata
+
+**Complexity:** 3
+**Tags:** cli, infrastructure, feature, docs


### PR DESCRIPTION
Epic covers two phases: (1) remote plan improvement via Linear/Notion MCP
without git, and (2) live repo doc sync enabling pure claude.ai planning.
Child plans: /improve-remote-plan skill, /sw-remote entry skill, and
kanban startup reconciler for offline status changes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011wXww2HSNXSyRSQDhvgDh1