### PR TITLE
Add three plans: epics gitignore exception, create-epic skill, gitignore audit

### DIFF
--- a/.switchboard/plans/create-epic-skill.md
+++ b/.switchboard/plans/create-epic-skill.md
@@ -1,0 +1,110 @@
+# Add `/create-epic` Skill for Remote Agent Epic Creation
+
+## Goal
+
+Create a `.claude/skills/create-epic/SKILL.md` skill that teaches agents how to create epics from a remote session (where the Switchboard VS Code extension is not running and `create-epic.js` cannot be used). The skill should tell the agent how to write an epic file directly to `.switchboard/epics/`, in the correct format, so the extension picks it up via the GlobalPlanWatcherService when VS Code reconnects.
+
+**Background:** `create-epic.js` routes through the running extension's LocalApiServer (`POST /kanban/epic`) and explicitly has no direct-DB fallback — it fails with a clear error if the extension is unreachable. This is by design for the local-VS Code case, but it means remote agents have no way to create epics today. The skill bridges this gap by teaching agents to write the file directly in the correct format.
+
+**Key constraint:** The epic file embeds the `planId` UUID in the filename (e.g. `my-epic-{uuid}.md`) so the watcher can derive the plan_id on re-import and preserve subtask→epic links. A bare slug would mint a fresh random ID on re-import and orphan every subtask. The skill must enforce this.
+
+## Metadata
+
+**Complexity:** 3
+**Tags:** cli, docs, infrastructure, reliability
+
+## Proposed Changes
+
+### [CREATE] `.claude/skills/create-epic/SKILL.md`
+
+The skill should cover the following, in order:
+
+**1. When to use this skill**
+- Agent is working in a remote session (no VS Code extension running)
+- User asks to create a new epic (grouping plans together, or creating a standalone epic)
+- Do NOT use this skill if the extension IS running — call `create-epic.js` instead (it's authoritative: does DB upsert, subtask linking, file write, and board refresh atomically)
+
+**2. How to detect whether the extension is running**
+- Check for `.switchboard/api-server-port.txt` in the workspace root
+- If present and the health endpoint responds (`GET http://127.0.0.1:{port}/health`), the extension is live — use `create-epic.js`
+- If absent or health check fails, proceed with direct file write
+
+**3. Epic file format**
+
+Epic files live in `.switchboard/epics/` and follow this structure:
+
+```markdown
+# {Epic Name}
+
+## Goal
+
+{Description of what this epic achieves and why it matters.}
+
+## How the Subtasks Achieve This
+
+{Narrative connecting the subtasks to the goal. Written once by the agent;
+preserved by _regenerateEpicFile on subsequent subtask changes.}
+
+<!-- BEGIN SUBTASKS -->
+<!-- END SUBTASKS -->
+
+## Metadata
+
+**Complexity:** {1–10}
+**Tags:** {comma-separated from standard tag list}
+```
+
+The `<!-- BEGIN SUBTASKS -->` / `<!-- END SUBTASKS -->` block is managed by the extension. Write it empty — the extension fills it in when the epic's subtasks are linked.
+
+**4. Filename convention**
+
+```
+{slug}-{planId}.md
+```
+
+- `slug`: lowercase, hyphens only, max 60 chars (e.g. `auth-refactor`)
+- `planId`: a fresh UUID v4 (generate with `node -e "const {randomUUID}=require('crypto');console.log(randomUUID())"`)
+- Full path: `.switchboard/epics/{slug}-{planId}.md`
+- **Never omit the planId from the filename** — the watcher derives the plan_id from this trailing UUID on re-import.
+
+**5. Linking existing plans as subtasks**
+
+After writing the epic file, to link existing plans (identified by their `planId` from `kanban-board.md`):
+
+```bash
+node .agents/skills/kanban_operations/assign-to-epic.js "{epicPlanId}" '["subtaskPlanId1","subtaskPlanId2"]' "{workspaceRoot}"
+```
+
+This also routes through the extension; in a remote session it will fail and the agent should note that subtask linking will need to be done when VS Code is next opened, OR the user can drag-and-drop in the kanban UI.
+
+**6. Sourcing existing suggest-epic content**
+
+The kanban UI's "Suggest Epics" button generates a detailed prompt (see `_buildSuggestEpicsPrompt` in `KanbanProvider.ts`) that:
+- Scans `kanban-board.md` for ungrouped plans in pre-coding columns
+- Groups them by theme
+- Proposes epic names and goals for user approval
+- Then calls `create-epic.js`
+
+The skill should reference this flow: if the user has not specified which plans to group, tell the agent to read `kanban-board.md`, propose groupings, get approval, then create the epic files.
+
+**7. After writing**
+
+- Commit the new file to git (the epics folder will be tracked once Plan `expose-epics-folder-in-gitignore.md` is deployed)
+- Note to the user that the extension will automatically import the epic into the kanban DB on next activation via the GlobalPlanWatcherService
+
+### [VERIFY] GlobalPlanWatcherService watches epics/
+
+Before finalising the skill, confirm that `GlobalPlanWatcherService.ts` sets up a file watcher on `.switchboard/epics/` (not just `.switchboard/plans/`). If it doesn't, the direct-file-write path is incomplete and the plan needs an additional task to add that watcher. Check for references to `epics` in `src/services/GlobalPlanWatcherService.ts`.
+
+## Verification Plan
+
+1. Read `GlobalPlanWatcherService.ts` to confirm `epics/` is watched — escalate to a separate plan if not.
+2. In a remote session (or with extension stopped), run the skill manually: generate a UUID, write an epic file following the format, confirm the file is valid markdown.
+3. Open VS Code → confirm the epic appears in the kanban board (GlobalPlanWatcherService import).
+4. Run the suggest-epics flow in the kanban UI → confirm it still works independently (this skill doesn't change the extension code).
+
+## Success Criteria
+
+1. `.claude/skills/create-epic/SKILL.md` exists with the format, filename convention, detection logic, and subtask-linking notes.
+2. An agent following the skill can produce a valid epic file that the extension imports on activation.
+3. Skill is registered in the skills table in `CLAUDE.md`.

--- a/.switchboard/plans/expose-epics-folder-in-gitignore.md
+++ b/.switchboard/plans/expose-epics-folder-in-gitignore.md
@@ -1,0 +1,59 @@
+# Expose `.switchboard/epics/` in Managed Gitignore Rules
+
+## Goal
+
+Add `!.switchboard/epics/` as an exception to Switchboard's managed gitignore block so that epic files are committed to the repository. Without this, remote coding sessions (Claude Code on the web, Jules, etc.) cannot see the epics folder — it's created at runtime but falls under the blanket `.switchboard/*` exclusion with no carve-out.
+
+**Root cause:** When epics were added, the `TARGETED_RULES` array in `WorkspaceExcludeService.ts` was not updated to mirror the treatment of `plans/`. Any user who runs setup (or whose gitignore is managed by Switchboard) has the folder silently excluded.
+
+## Metadata
+
+**Complexity:** 2
+**Tags:** backend, infrastructure, devops, reliability
+
+## Proposed Changes
+
+### [MODIFY] `src/services/WorkspaceExcludeService.ts` — Add epics exception
+
+In `TARGETED_RULES` (lines 9–28), add `!.switchboard/epics/` immediately after `!.switchboard/plans/`:
+
+```typescript
+// BEFORE:
+'!.switchboard/reviews/',
+'!.switchboard/plans/',
+'!.switchboard/sessions/',
+
+// AFTER:
+'!.switchboard/reviews/',
+'!.switchboard/plans/',
+'!.switchboard/epics/',
+'!.switchboard/sessions/',
+```
+
+### [MODIFY] `src/test/git-ignore-custom-default-regression.test.js` — Update snapshot
+
+The regression test validates the exact content of `TARGETED_RULES`. It will fail without a matching update. Add `!.switchboard/epics/` in the same position to the expected rules array.
+
+Locate the assertion that checks for `!.switchboard/plans/` and insert the epics line directly after it.
+
+### [CHECK] `src/webview/setup.html` — Warning text
+
+The setup tab contains a warning (around line 632–634) that references `plans/` specifically. Review whether this text should be updated to also mention `epics/` for clarity. This is documentation-only; not a functional change.
+
+## Migration Consideration
+
+This is an **additive change** to the managed block. Existing users who already have a managed block in their `.gitignore` will get the new line added on the next time `WorkspaceExcludeService.apply()` runs (extension activation or settings change). The epics folder, if it exists, will immediately become tracked — which is the desired outcome.
+
+Users on the `custom` or `none` strategy are unaffected (they manage their own rules).
+
+## Verification Plan
+
+1. Run the existing gitignore regression test: `node src/test/git-ignore-custom-default-regression.test.js` — must pass.
+2. In a test workspace, create an epic via the kanban UI and confirm `git status` shows `.switchboard/epics/*.md` as untracked (i.e., no longer ignored).
+3. Run Switchboard setup → confirm the managed block in `.gitignore` includes `!.switchboard/epics/`.
+
+## Success Criteria
+
+1. `TARGETED_RULES` contains `!.switchboard/epics/` in the correct position.
+2. Regression test passes.
+3. A freshly created epic file appears in `git status` as an untracked file (not silently ignored).

--- a/.switchboard/plans/gitignore-rules-audit.md
+++ b/.switchboard/plans/gitignore-rules-audit.md
@@ -11,17 +11,27 @@ Review whether Switchboard's `TARGETED_RULES` gitignore block is still appropria
 **Complexity:** 3
 **Tags:** infrastructure, devops, docs, reliability
 
+## ⚠️ Reviewer Note: Inspect the Live `.switchboard/` Directory
+
+**This audit was written from a remote clone where the Switchboard extension has never run.** The remote `.switchboard/` only contains committed files (`plans/`, `sessions/`, `kanban-board.md`, etc.). None of the extension-generated directories exist in this environment.
+
+Before finalising the recommendations below, the implementer must **inspect `.switchboard/` on a local machine where the extension has been running** (ideally the primary dev machine). Some directories that were categorised as "cache" from code inspection alone may in practice contain real, durable artifacts — for example, `docs/` holds imported documents that users may want committed and visible to remote agents, not regenerated on every clone.
+
+**Action required before implementation:** Run `find .switchboard -maxdepth 3 | sort` on a live local workspace and review each directory with the owner. Revise the recommendations table below based on actual observed content before touching `TARGETED_RULES`.
+
+---
+
 ## Findings from Audit
 
-### What still legitimately writes files (should remain excluded or kept)
+### What still legitimately writes files (recommendations are provisional — see note above)
 
-| Path | Status | Recommendation |
+| Path | Status | Provisional Recommendation |
 |:---|:---|:---|
 | `.switchboard/kanban.db` / `*.db-shm` / `*.db-wal` | Machine-local DB | **Keep excluded** — never commit |
-| `.switchboard/docs/` | Integration doc cache (machine-local) | **Keep excluded** — per-machine cache |
-| `.switchboard/tickets/` | Ticket cache hierarchy | **Keep excluded** — per-machine cache |
-| `.switchboard/planning-cache/` | Doc ID mappings cache | **Keep excluded** — per-machine cache |
-| `.switchboard/archive/` | Archived plans/reviews | **Keep excluded** — machine-local history |
+| `.switchboard/docs/` | Imported docs from Linear/ClickUp/Notion | **Needs review** — may be real artifacts worth committing for remote agents, not pure cache |
+| `.switchboard/tickets/` | Ticket cache hierarchy | **Needs review** — may contain curated content vs. raw API cache |
+| `.switchboard/planning-cache/` | Doc ID mappings cache | **Keep excluded** — internal ID mapping, regenerable |
+| `.switchboard/archive/` | Archived plans/reviews | **Needs review** — archived plans are durable history; remote agents may benefit from seeing them |
 | `.switchboard/*-config.json` (clickup, linear, notion) | Encrypted credentials | **Keep excluded** — never commit secrets |
 | `.switchboard/workspace-id` | Local DB path pointer | **Keep excluded** — machine-local |
 | `.switchboard/notion-cache.md` | Notion page cache | **Keep excluded** (currently duplicated — see below) |

--- a/.switchboard/plans/gitignore-rules-audit.md
+++ b/.switchboard/plans/gitignore-rules-audit.md
@@ -1,0 +1,135 @@
+# Audit and Trim Switchboard's Managed Gitignore Rules
+
+## Goal
+
+Review whether Switchboard's `TARGETED_RULES` gitignore block is still appropriate now that the project has moved to a SQLite DB model for runtime state. Remove rules that are no longer needed, fix gaps (epics folder — covered in a separate plan), and reduce noise for users who wonder why so much of `.switchboard/` is excluded.
+
+**Background:** Switchboard originally wrote many files to `.switchboard/` — `state.json`, `kanban-state.json`, `sessions/activity.jsonl`, etc. These justified the blanket `.switchboard/*` exclusion. Most of that file spam has been migrated to `kanban.db`. But the exclusion rules have never been revisited post-migration, so the current rule set may be overly broad or contain redundant entries.
+
+## Metadata
+
+**Complexity:** 3
+**Tags:** infrastructure, devops, docs, reliability
+
+## Findings from Audit
+
+### What still legitimately writes files (should remain excluded or kept)
+
+| Path | Status | Recommendation |
+|:---|:---|:---|
+| `.switchboard/kanban.db` / `*.db-shm` / `*.db-wal` | Machine-local DB | **Keep excluded** — never commit |
+| `.switchboard/docs/` | Integration doc cache (machine-local) | **Keep excluded** — per-machine cache |
+| `.switchboard/tickets/` | Ticket cache hierarchy | **Keep excluded** — per-machine cache |
+| `.switchboard/planning-cache/` | Doc ID mappings cache | **Keep excluded** — per-machine cache |
+| `.switchboard/archive/` | Archived plans/reviews | **Keep excluded** — machine-local history |
+| `.switchboard/*-config.json` (clickup, linear, notion) | Encrypted credentials | **Keep excluded** — never commit secrets |
+| `.switchboard/workspace-id` | Local DB path pointer | **Keep excluded** — machine-local |
+| `.switchboard/notion-cache.md` | Notion page cache | **Keep excluded** (currently duplicated — see below) |
+| `.switchboard/insights/`, `stitch/`, `NotebookLM/` | Caches/staging | **Keep excluded** |
+| `.switchboard/inbox/`, `outbox/`, `cooldowns/`, `MCP/`, `handoff/` | Transient runtime | **Keep excluded** |
+| `.switchboard/kanban-state-backup.json` | Recovery backup | **Keep excluded** — machine-local |
+
+### What has been migrated to DB (rules are now redundant documentation)
+
+| Path | Migration Status | Notes |
+|:---|:---|:---|
+| `.switchboard/state.json` | Fully bridged to DB | File never written — transparent bridge routes all calls to `kanban.db`. The explicit gitignore entry serves as documentation only. |
+| `.switchboard/sessions/activity.jsonl` | Migrated to DB sessions table | Renamed to `activity.jsonl.migrated` on disk. New activity goes to DB. |
+
+### The `sessions/` exception — questionable
+
+`!.switchboard/sessions/` is a current exception (sessions are committed). But `sess_*.json` files are per-machine session archives — machine-local metadata that differs per developer. Committing them creates noise with zero benefit for remote agents (they don't read session archives). **Recommendation: remove this exception.** 
+
+Migration note: existing users who have committed `sessions/` files should not have those deleted — just exclude new ones going forward. The gitignore change only affects untracked files; already-committed files require a separate `git rm --cached` by the user if they want to clean up.
+
+### Redundant explicit entries
+
+The managed block explicitly lists entries that are already covered by `.switchboard/*`:
+- `.switchboard/notion-cache.md` — redundant (covered by `*`)
+- `.switchboard/kanban.db`, `*.db-shm`, `*.db-wal` — redundant but kept as **intentional documentation** (the comment explains why the DB is excluded)
+
+The notion-cache.md explicit entry has no documentary value beyond what the wildcard provides. It can be removed.
+
+## Proposed Changes
+
+### [MODIFY] `src/services/WorkspaceExcludeService.ts` — Trim TARGETED_RULES
+
+```typescript
+// BEFORE:
+private static readonly TARGETED_RULES: string[] = [
+    '# Switchboard runtime state (per-session, not shareable)',
+    '.switchboard/*',
+    '!.switchboard/reviews/',
+    '!.switchboard/plans/',
+    '!.switchboard/sessions/',       // <-- remove
+    '!.switchboard/CLIENT_CONFIG.md',
+    '!.switchboard/README.md',
+    '!.switchboard/SWITCHBOARD_PROTOCOL.md',
+    '!.switchboard/kanban-board.md',
+    '',
+    '# Notion page content cache',
+    '.switchboard/notion-cache.md',  // <-- remove (covered by wildcard, no doc value)
+    '',
+    '# kanban.db is already excluded by .switchboard/* above — explicit entry for documentation clarity.',
+    '# Never commit the kanban database: it contains machine-local state that differs per developer.',
+    '.switchboard/kanban.db',
+    '.switchboard/*.db-shm',
+    '.switchboard/*.db-wal',
+];
+
+// AFTER (combined with the epics addition from the companion plan):
+private static readonly TARGETED_RULES: string[] = [
+    '# Switchboard runtime state (per-session, not shareable)',
+    '.switchboard/*',
+    '!.switchboard/reviews/',
+    '!.switchboard/plans/',
+    '!.switchboard/epics/',
+    '!.switchboard/CLIENT_CONFIG.md',
+    '!.switchboard/README.md',
+    '!.switchboard/SWITCHBOARD_PROTOCOL.md',
+    '!.switchboard/kanban-board.md',
+    '',
+    '# kanban.db is already excluded by .switchboard/* above — explicit entry for documentation clarity.',
+    '# Never commit the kanban database: it contains machine-local state that differs per developer.',
+    '.switchboard/kanban.db',
+    '.switchboard/*.db-shm',
+    '.switchboard/*.db-wal',
+];
+```
+
+**Note:** This plan can be merged with `expose-epics-folder-in-gitignore.md` into a single implementation pass since both touch the same constant and test file.
+
+### [MODIFY] `src/test/git-ignore-custom-default-regression.test.js` — Update snapshot
+
+Remove `!.switchboard/sessions/` and `.switchboard/notion-cache.md` from the expected rules. Add `!.switchboard/epics/`. The test must pass after changes.
+
+### [CHECK] `.gitignore` (repo-level, non-managed section)
+
+The repo's `.gitignore` (above the managed block) also manually lists some entries:
+- `.switchboard/clickup-config.json`
+- `.switchboard/linear-config.json`
+- `.switchboard/linear-sync.json`
+- `.switchboard/notion-config.json`
+- `.switchboard/notion-cache.md`
+
+These are outside the managed block and cover the case where users have `custom` or `none` strategy. They should stay. No changes needed here.
+
+## Migration Consideration
+
+Removing `!.switchboard/sessions/` from `TARGETED_RULES` does NOT delete already-committed session files. It only means the gitignore stops carving out an exception for new ones. Users who have committed session files and want to clean up can run `git rm --cached .switchboard/sessions/*.json`. This is optional and can be mentioned in release notes.
+
+The `WorkspaceExcludeService.apply()` method rewrites only the managed block on next run — it will remove the old exception and add the new epics one atomically.
+
+## Verification Plan
+
+1. Run regression test — must pass with updated snapshot.
+2. Confirm `!.switchboard/sessions/` is no longer in the managed block written to `.gitignore`.
+3. Confirm `!.switchboard/epics/` IS in the managed block.
+4. Confirm `git status` does not show `.switchboard/sessions/*.json` as newly untracked (they stay committed; gitignore only affects untracked files).
+
+## Success Criteria
+
+1. `TARGETED_RULES` has: epics exception added, sessions exception removed, notion-cache.md redundant entry removed.
+2. Regression test passes.
+3. Managed gitignore block written to disk matches the new rules exactly.
+4. No existing committed files are deleted or newly ignored.


### PR DESCRIPTION
- expose-epics-folder-in-gitignore.md: add !.switchboard/epics/ to
  TARGETED_RULES so remote sessions can see epic files
- create-epic-skill.md: new /create-epic skill for writing epics directly
  when the VS Code extension is not running (remote sessions)
- gitignore-rules-audit.md: audit findings — sessions/ exception should be
  removed, notion-cache.md redundant entry cleaned up; blanket exclusion
  still justified given volume of cache/config/transient file output

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KPU9eSCGEeaiFcFXWaS8Tf