### PR TITLE
docs: update remote-control docs for provider-agnostic remote sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,21 @@ Configure via: `switchboard.defaultMode` (`action` | `plan`)
 ### Automated Triage Pipeline (ClickUp & Linear)
 One-click setup in the Setup panel creates a "Bug Triage" board that auto-pulls bugs from ClickUp or Linear, routes them to the Ticket Updater agent for triage verdicts (severity, area, recommended action, routing), and syncs the verdicts back as comments on the source ticket. The agent never overwrites the ticket description — it posts a short structured comment only (target ≤120 words).
 
-### Linear Remote Control
-Drive your Kanban board from the Linear app on your phone. Moving a card between Linear states moves it on the board and dispatches that column's agent. Comments posted on a Linear issue are routed to the card's current column agent. Configure boards, sync mode, and ping frequency in the Kanban REMOTE tab. Toggle remote control from the toolbar button. Config is stored in the Kanban database (key `remote.config`), not in `settings.json`.
+### Remote Control (provider-agnostic)
+Drive your Kanban board from a remote surface — the **Linear** or **Notion** mobile/web app, or a **ClickUp** mirror. Switchboard polls the active provider on a timer (no webhooks): moving a card between remote states mirrors it onto the board and dispatches that column's agent, and comments posted remotely are routed to the card's current column agent.
+
+Configure it in the **Project panel → REMOTE tab**; start/stop from the Kanban toolbar remote-control button. Controls:
+- **Provider** — Linear, Notion, or ClickUp (push-only stakeholder mirror).
+- **Boards to sync** — pick which project boards participate.
+- **Remote mode** — *Ingest (pull only)* mirrors remote state without dispatching, or *Full (pull + mirror + dispatch)* also runs the column agent. (Full is disabled for push-only providers.)
+- **Poll comments from remote** and **Push status & content to remote** — independent toggles (push is disabled for providers that don't support it).
+- **Silent syncing** — keep boards mirrored even while pinging is off.
+- **Ping frequency** — 30–120s (default 60).
+
+A **Sync Health** panel surfaces last poll/push status, rate-limit backoff, and persistent-failure warnings so silent breakage (bad token, revoked connection) is visible. Config is stored in the Kanban database (key `remote.config`), not in `settings.json`.
+
+### Board State Export (git-native mirror)
+Independently of the provider channel, Switchboard can mirror board state to git so it travels with your repo. Set **Board State Export** in the Setup panel — `none` (no git footprint), `control-plane` (push to the control-plane repo), or `wiki` (push to `<remote>.wiki.git`). Settings: `switchboard.boardStateExport`, `switchboard.boardStateExport.remoteUrl`.
 
 ### Live Sync Mode
 Automatically syncs edits back to ClickUp/Linear every 30 seconds.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Configure roles:
 - **Ticket Updater** — Reads imported tickets and posts short triage verdicts (severity, area, recommended action) back to ClickUp/Linear as comments.
 - **Orchestrator** — Runs an entire Epic end-to-end with native subagents (off by default; enable in the Kanban Agents tab).
 - **Claude Designer** — Imports a design from claude.ai/design into the target folder using the repo's existing components and styles (off by default).
+- **MCP Monitor** — Read-only monitor role; on an interval it pings a dedicated Claude terminal to check connected MCP sources (Slack, Gmail, Google Calendar, custom) and report what needs attention (off by default).
 
 You can add custom roles in the Setup panel.
 
@@ -141,6 +142,9 @@ Configure per column:
 - Timing interval
 - Batch size
 
+### MCP Monitor
+Also in the Automation panel: turn on the **MCP Monitor** to have Switchboard periodically ping a dedicated Claude terminal that checks your connected MCP sources (Slack, Gmail, Google Calendar, or a custom instruction) and reports anything needing attention. Pick a single global interval (1–30 min) and the sources to watch; a status line shows whether the monitor terminal is running. Off by default.
+
 ---
 
 ## Project Management & Sync
@@ -165,13 +169,17 @@ On the Kanban board, epic cards show a purple left border and an `EPIC · N subt
 **Worktree isolation** — An epic can be bound to a dedicated git worktree/branch so its agents work in isolation. Manage worktrees from the Kanban WORKTREES panel; dispatched agents `cd` into the worktree and switch to its branch automatically, and the worktree can later be merged or abandoned.
 
 ### ClickUp & Linear Sync
-Configure tokens and mappings in Setup.
+Configure tokens in Setup.
 Commands:
 - `Set ClickUp API Token`
 - `Set Linear API Token`
 - `Import Tasks from ClickUp`
 - `Import Issues from Linear`
 Settings: `switchboard.kanban.completedLimit`, `switchboard.kanban.dbPath`
+
+Beyond token + import, both integrations now do more:
+- **ClickUp** (push-only mirror — pushes out, doesn't poll back): outbound content push, move a task between lists (with status auto-mapping), epic round-trip (import parent+subtasks as an epic; push local epics out as native parent/child tasks), plus agent-driven task/comment/attachment/doc creation.
+- **Linear** (full two-way): bidirectional description sync (Linear edits flow back into the plan file), status/column sync via Remote Control, move an issue between projects, epic round-trip, comments + attachments captured on import, and archive/unarchive used by the Auto-Archive rule.
 
 ### Notion Design Doc Integration
 Fetch, cache, and append design documents to prompts.
@@ -182,8 +190,10 @@ Commands: `Set Notion API Token`, `Fetch Notion Design Doc`
 - **Board Management Mode** — Pulls tasks automatically, processes cards independently, and writes back only when `COMPLETED`.
 Configure via: `switchboard.defaultMode` (`action` | `plan`)
 
-### Automated Triage Pipeline (ClickUp & Linear)
-One-click setup in the Setup panel creates a "Bug Triage" board that auto-pulls bugs from ClickUp or Linear, routes them to the Ticket Updater agent for triage verdicts (severity, area, recommended action, routing), and syncs the verdicts back as comments on the source ticket. The agent never overwrites the ticket description — it posts a short structured comment only (target ≤120 words).
+### Automated Triage Pipeline (ClickUp & Linear) — *pre-release, not currently exposed*
+> The one-click triage setup and the ClickUp/Linear **Kanban Board Mapping** and **Kanban Automation** setup sections are hidden in the current build while they're hardened. The Ticket Updater agent and triage flow still exist under the hood, but there's no UI to enable them yet.
+
+When exposed: one-click setup creates a "Bug Triage" board that auto-pulls bugs from ClickUp or Linear, routes them to the Ticket Updater agent for triage verdicts (severity, area, recommended action, routing), and syncs the verdicts back as comments on the source ticket. The agent never overwrites the ticket description — it posts a short structured comment only (target ≤120 words).
 
 ### Remote Control (provider-agnostic)
 Drive your Kanban board from a remote surface — the **Linear** or **Notion** mobile/web app, or a **ClickUp** mirror. Switchboard polls the active provider on a timer (no webhooks): moving a card between remote states mirrors it onto the board and dispatches that column's agent, and comments posted remotely are routed to the card's current column agent.
@@ -209,6 +219,9 @@ Automatically syncs edits back to ClickUp/Linear every 30 seconds.
 
 ### Auto-Pull Timers
 Optionally enable automatic updates on a 5/15/30/60-minute timer.
+
+### Auto-Archive Rule
+Automatically complete + archive a plan once it has sat in a designated board column past a dwell threshold — useful for keeping a board (and a free-tier Linear workspace) from filling up. Configure on the Kanban Setup tab: enable checkbox, trigger column, and dwell hours (default 2). Off by default. Note the dwell timer keys off the plan's `updatedAt`, so editing or commenting on a plan resets its clock.
 
 ---
 
@@ -270,7 +283,7 @@ Settings:
 - **Kanban** (`switchboard.openKanban`) — Visual board plus tabs for Agents, Prompts, Automation, Remote, Worktrees, UAT, and Setup. Projects are created here (board toolbar) and the PROJECT CONTEXT toggle lives here.
 - **Setup** (`switchboard.openSetupPanel`) — Central configuration.
 - **Planning** (`switchboard.openPlanningPanel`) — Authoring interface.
-- **Project Panel** (`switchboard.openProjectPanel`) — Projects (per-project PRDs), Epics, Constitution, and System docs.
+- **Project Panel** (`switchboard.openProjectPanel`) — Projects (per-project PRDs), Epics, Constitution, System docs, Tuning insights, the **Architect** tab (guided governance setup), and the **Remote** tab (Remote Control config).
   ![Project panel — Constitution](docs/TODO_project_panel.png)
 - **Design Panel** (`switchboard.openDesignPanel`) — Six tabs: STITCH (Google Stitch), CLAUDE (claude.ai/design import), BRIEFS, HTML PREVIEWS, IMAGES, DESIGN SYSTEM.
   ![Design panel — Stitch](docs/TODO_design_panel.png)

--- a/docs/how_to_use_switchboard.md
+++ b/docs/how_to_use_switchboard.md
@@ -66,8 +66,18 @@ Access unlimited Gemini Pro planning quota:
 ### One-Click Triage Pipeline
 In the Setup panel, click "ENABLE TRIAGE PIPELINE" under ClickUp or Linear to auto-create a Bug Triage board. Bugs are pulled in, routed to the Ticket Updater agent, and triage verdicts (severity, area, assessment, recommended action, routing — ≤120 words) are synced back as comments. The agent never overwrites the ticket description.
 
-### Linear Remote Control
-Drive your board from your phone via the Linear app. Configure in the Kanban REMOTE tab — select boards, set ping mode (manual/constant), and ping frequency (30-120s). Moving a Linear issue between states dispatches the corresponding Kanban column agent; comments are routed to the current column's agent. Toggle from the toolbar remote control button. Config stored in the Kanban DB, not `settings.json`.
+### Remote Control (Linear / Notion / ClickUp)
+Drive your board from your phone or browser via a remote provider. Configure it in the **Project panel → REMOTE tab** and toggle it on/off from the Kanban toolbar remote-control button:
+- **Provider** — Linear, Notion, or ClickUp (push-only mirror).
+- **Boards to sync** — which project boards participate.
+- **Remote mode** — *Ingest (pull only)* just mirrors remote state; *Full (pull + mirror + dispatch)* also dispatches the target column's agent.
+- **Poll comments from remote** / **Push status & content to remote** — independent toggles.
+- **Silent syncing** — keep mirroring even while pinging is off.
+- **Ping frequency** — 30–120s (default 60).
+
+Moving a remote issue between states dispatches the corresponding Kanban column agent (in Full mode); comments are routed to the current column's agent. A **Sync Health** panel shows last poll/push status, rate-limit backoff, and persistent-failure warnings. Config is stored in the Kanban DB (key `remote.config`), not `settings.json`.
+
+Separately, **Board State Export** (Setup panel) mirrors board state to git — `none`, `control-plane`, or `wiki` — via `switchboard.boardStateExport`.
 
 ---
 

--- a/docs/how_to_use_switchboard.md
+++ b/docs/how_to_use_switchboard.md
@@ -29,6 +29,9 @@ The Project Constitution is your spec-driven governance model. Instead of typing
 - **Use per-project PRDs for requirements.** Create a project on the Kanban board, write its requirements on the Project Panel's **PROJECTS** tab (saved to `.switchboard/projects/<project>/prd.md`), and flip the **PROJECT CONTEXT** toggle (on the Kanban board) on. The active project's PRD is then injected — under the header `PROJECT REQUIREMENTS (PRD):` — into *every* dispatched prompt (planner, lead, coder, reviewer, tester, orchestrator), not just the planner. This is the modern replacement for the legacy planner-only Design Doc setting.
 - Set up a Notion design doc integration to fetch and cache external PRDs directly.
 
+### Let the Architect guide you
+If you're not sure where to start with governance, open the **Project panel → ARCHITECT** tab and click **Open Architect Terminal**. It launches a guided session (through your Planner terminal) that walks you through writing and refining your PRD, Constitution, `CLAUDE.md`/`AGENTS.md` system files, and tuning insights, showing which of those docs already exist. Prefer to paste it into a chat agent instead? Use **Copy Architect Prompt**.
+
 ---
 
 ## 3. Quota-Saving and Optimization Tactics
@@ -63,8 +66,8 @@ Access unlimited Gemini Pro planning quota:
 
 ## 4. Automated Triage & Remote Control
 
-### One-Click Triage Pipeline
-In the Setup panel, click "ENABLE TRIAGE PIPELINE" under ClickUp or Linear to auto-create a Bug Triage board. Bugs are pulled in, routed to the Ticket Updater agent, and triage verdicts (severity, area, assessment, recommended action, routing — ≤120 words) are synced back as comments. The agent never overwrites the ticket description.
+### One-Click Triage Pipeline *(pre-release — currently hidden)*
+The triage setup, along with the ClickUp/Linear **Kanban Board Mapping** and **Kanban Automation** setup sections, is hidden in the current build while it's hardened; the underlying Ticket Updater flow still exists but isn't exposed in the UI. When available: in the Setup panel, click "ENABLE TRIAGE PIPELINE" under ClickUp or Linear to auto-create a Bug Triage board. Bugs are pulled in, routed to the Ticket Updater agent, and triage verdicts (severity, area, assessment, recommended action, routing — ≤120 words) are synced back as comments. The agent never overwrites the ticket description.
 
 ### Remote Control (Linear / Notion / ClickUp)
 Drive your board from your phone or browser via a remote provider. Configure it in the **Project panel → REMOTE tab** and toggle it on/off from the Kanban toolbar remote-control button:
@@ -78,6 +81,12 @@ Drive your board from your phone or browser via a remote provider. Configure it 
 Moving a remote issue between states dispatches the corresponding Kanban column agent (in Full mode); comments are routed to the current column's agent. A **Sync Health** panel shows last poll/push status, rate-limit backoff, and persistent-failure warnings. Config is stored in the Kanban DB (key `remote.config`), not `settings.json`.
 
 Separately, **Board State Export** (Setup panel) mirrors board state to git — `none`, `control-plane`, or `wiki` — via `switchboard.boardStateExport`.
+
+### MCP Monitor — watch your comms without leaving the board
+Turn on the **MCP Monitor** in the Kanban Automation panel to have Switchboard ping a dedicated Claude terminal on an interval (1–30 min) that checks your connected MCP sources — Slack, Gmail, Google Calendar, or a custom instruction — and reports anything needing attention in that terminal pane. Pick the sources to watch and the cadence; the status line shows whether the monitor terminal is running (launch it if not). Off by default, and read-only — it never dispatches work.
+
+### Auto-Archive — keep the board (and free-tier limits) tidy
+On the Kanban **Setup** tab, enable the **Auto-Archive Rule** to automatically complete + archive any plan that sits in a chosen column past a dwell threshold (default 2 hours). The archive rides your unified push out to Linear/Notion, which helps stay under Linear's free-tier active-issue cap. Off by default. Heads-up: the dwell clock uses the plan's last-updated time, so editing or commenting on a plan resets it — a busy plan may never auto-archive.
 
 ---
 

--- a/docs/switchboard_user_manual.md
+++ b/docs/switchboard_user_manual.md
@@ -35,7 +35,7 @@
 27. [Webview Panels Reference](#27-webview-panels-reference)
 28. [Memo Capture Mode](#28-memo-capture-mode)
 29. [Automated Triage Pipeline](#29-automated-triage-pipeline)
-30. [Linear Remote Control](#30-linear-remote-control)
+30. [Remote Control (provider-agnostic)](#30-remote-control-provider-agnostic)
 31. [Troubleshooting / FAQ](#31-troubleshooting--faq)
 32. [Using Switchboard with claude.ai](#32-using-switchboard-with-claudeai)
 
@@ -1203,7 +1203,7 @@ The board itself with drag-and-drop columns. Controls strip:
 - **PROJECT CONTEXT** — Toggle (off by default). When on, the active project's PRD (authored on the Project Panel's PROJECTS tab) is injected into every dispatched prompt across all roles.
 - **Scan Folders** — Force immediate plan scan (`switchboard.triggerPlanScan`).
 - **AUTOBAN** — Start/stop the automation engine.
-- **Remote Control** — Start/stop Linear remote control.
+- **Remote Control** — Start/stop remote control (Linear / Notion / ClickUp; configured in the Project panel → REMOTE tab).
 - **CLI Triggers** — Toggle between CLI terminal dispatch and clipboard prompt mode.
 - **Collapse Coders** — Toggle collapsed view for coder columns.
 - **Pair Programming Mode** dropdown — Select CLI Parallel / Hybrid / Full Clipboard.
@@ -1232,8 +1232,8 @@ Per-role prompt customization:
 **AUTOMATION Tab**
 Automation panel for configuring AUTOBAN rules and timing per column. Includes batch size, complexity filter, routing mode, max sends per terminal, global session cap, and terminal pool management.
 
-**REMOTE Tab**
-Configure Linear Remote Control — select boards, sync mode (manual/constant), and ping frequency. See §30.
+**REMOTE Tab** (Project panel)
+Configure Remote Control — provider (Linear / Notion / ClickUp), boards to sync, remote mode (Ingest / Full), comment-polling and push toggles, silent syncing, and ping frequency. Includes a Sync Health panel. See §30. (This config tab lives in the Project panel; the start/stop toggle is on the Kanban toolbar.)
 
 **WORKTREES Tab**
 Manage git worktrees for epic-based dispatch routing. Create, list, and delete worktrees associated with epics.
@@ -1498,21 +1498,43 @@ The verdict is posted via the `clickup_api` or `linear_api` skill — it **never
 
 ---
 
-## 30. Linear Remote Control
+## 30. Remote Control (provider-agnostic)
 
-Drive your Kanban board from the Linear mobile app.
+Drive your Kanban board from a remote surface — the **Linear** or **Notion** mobile/web app, or a push-only **ClickUp** mirror.
 
 ### How It Works
-Remote Control polls Linear on a timer (no webhooks), mirrors state changes to Kanban columns and dispatches the column's agent, and ingests comments — routing each to the current column's agent.
+Remote Control polls the active provider on a timer (no webhooks). In **Full** mode it mirrors remote state changes onto Kanban columns and dispatches the target column's agent; in either mode it ingests comments and routes each to the current column's agent. Delta polling asks the provider "what changed since my cursor?" — state and comments are two separate streams with two cursors.
+
+### Providers & capabilities
+Providers implement a common seam and declare capabilities (`pull`, `push`, `projectContextPush`, `archive`); the UI gates controls on capability, not on provider name.
+
+| Provider | Pull | Push | Notes |
+| :--- | :--- | :--- | :--- |
+| **Linear** | ✓ | ✓ | Full remote-control surface. |
+| **Notion** | ✓ | ✓ | Full; drive via the Notion app / MCP. |
+| **ClickUp** | — | ✓ | Push-only stakeholder-visibility mirror (no inbound dispatch). |
+
+(A separate **git-native** channel — control-plane / wiki — mirrors whole-board state via git; see *Board State Export* below and §on the Control Plane. It is configured by `switchboard.boardStateExport`, not by this tab.)
 
 ### Configuration
-Kanban **REMOTE** tab:
-- **Boards to sync** (multi-select)
-- **Silent sync** — keep mirroring while pinging is off
-- **Ping mode** — manual / constant
+Configure in the **Project panel → REMOTE** tab (the config tab moved here from the Kanban panel; only the start/stop toggle remains on the Kanban toolbar):
+- **Provider** — Linear / Notion / ClickUp (push-only)
+- **Workspace** and **Boards to sync** (multi-select)
+- **Silent syncing** — keep selected boards mirrored even while pinging is off
+- **Remote mode** — *Ingest (pull only)* or *Full (pull + mirror + dispatch)*. Full is disabled for providers without `pull`.
+- **Poll comments from remote** — comment-polling toggle
+- **Push status & content to remote** — push toggle; disabled for providers without `push`
 - **Ping frequency** — 30–120s (default 60)
+- **Start / Stop Remote Control** button (active state shows "Pinging…")
 
-Toggle remote control on/off from the toolbar remote control button.
+Toggle remote control on/off from the Kanban toolbar remote-control button as well.
+
+### Sync Health
+While remote control is active, a **Sync Health** panel (auto-refreshed ~every 15s) surfaces:
+- **Last poll** — ✓/✗ with timestamp and truncated error (red on failure)
+- **Last push** — ✓/✗ with timestamp and error
+- **Rate-limit backoff** — "⏳ Rate-limited — backing off…" when the provider returns 429/529 (60s window)
+- **Persistent failure** — "⚠ N consecutive failures — check token/connection" once failures reach 3
 
 ### Guards
 - **Self-comment marker** — skips its own outbound comments on ingest.
@@ -1522,7 +1544,15 @@ Toggle remote control on/off from the toolbar remote control button.
 - **Per-poll card cap** — 100 cards (most-recently-updated first; remainder deferred to the next cycle).
 
 ### Config Storage
-Stored in the Kanban DB `config` table (key `remote.config`), **not** in `settings.json`. The `RemoteConfig` fields: `boards` (string[]), `silentSync` (boolean), `pingFrequencySeconds` (30–120, default 60). The poll loop runs when the toolbar toggle is on and stops when it's off.
+Stored in the Kanban DB `config` table (key `remote.config`), **not** in `settings.json`. The `RemoteConfig` fields: `provider` (`linear`|`notion`|`clickup`), `boards` (string[]), `silentSync` (boolean), `pingFrequencySeconds` (30–120, default 60), `mode` (`ingest`|`full`), `push` (boolean), `comments` (boolean). The poll loop runs when the toolbar toggle is on and stops when it's off.
+
+### Board State Export (git-native mirror)
+Independently of the provider channel above, board state can be mirrored to git so it travels with the repo. Set the destination in the **Setup** panel → *Board State Export*:
+- `none` — no git footprint (default)
+- `control-plane` — push to the control-plane repo
+- `wiki` — push to `<remote>.wiki.git`
+
+Outbound pushes commit `.switchboard/kanban-board.md` and `.switchboard/kanban-state-*.md` ("switchboard: update board state mirror"); inbound state/comment deltas are read back from git with a commit-SHA cursor and an author trust gate (`switchboard.planAutoFetch.trustedAuthors`). Settings: `switchboard.boardStateExport`, `switchboard.boardStateExport.remoteUrl`.
 
 ---
 

--- a/docs/switchboard_user_manual.md
+++ b/docs/switchboard_user_manual.md
@@ -97,6 +97,7 @@ Switchboard ships with the following built-in agent roles (defined in `agentConf
 | `gatherer` | Context Gatherer | Gathers code context before planning. |
 | `orchestrator` | Orchestrator | Runs an entire Epic end-to-end with native subagents. Off by default — enable in the Kanban Agents tab to dispatch epics directly (otherwise **Orchestrate** copies the prompt). Defaults to a subagent-per-subtask policy and can optionally use a git worktree per plan. See §8 (Epics). |
 | `claude_designer` | Claude Designer | Imports a design from claude.ai/design into a target folder using the repo's existing components and styles. Off by default. See §9 (Design Panel → CLAUDE tab). |
+| `mcp_monitor` | MCP Monitor | Monitor-only role. On an interval it pings a dedicated Claude terminal to check your connected MCP sources (Slack, Gmail, Google Calendar, custom) and report anything needing attention. Off by default; it is read-only and cannot receive execute dispatches. See §4 (MCP Monitor). |
 
 ### Custom Roles
 Add custom agents in the Setup panel. Each custom agent supports:
@@ -181,6 +182,15 @@ Additional AUTOBAN settings:
 - **Terminal pools** — Up to 5 terminals per role, rotated round-robin
 
 Commands: `switchboard.setAutobanEnabledFromKanban`, `switchboard.setAutobanPausedFromKanban`, `switchboard.resetAutobanTimersFromKanban`, `switchboard.addAutobanTerminalFromKanban`, `switchboard.removeAutobanTerminalFromKanban`, `switchboard.resetAutobanPoolsFromKanban`
+
+### MCP Monitor
+The **MCP Monitor** watches your connected MCP sources on a timer and surfaces anything that needs attention — without you having to open Slack/Gmail/Calendar yourself. It runs in the Kanban **Automation** panel:
+- **MCP MONITOR** on/off dropdown.
+- **Interval** — 1 / 2 / 5 / 10 / 15 / 30 minutes (one global cadence; default 5 min, off).
+- **Watched Sources** — checklist of **Slack**, **Gmail**, **Google Calendar**, and **Custom** (with a free-text custom-instruction box).
+- **Status line + Launch Monitor Terminal** — shows "🟢 Monitor terminal: running" or "🔴 No monitor terminal running", and launches the dedicated terminal.
+
+On each tick Switchboard sends a read-only prompt to the dedicated "MCP Monitor" Claude terminal, which checks the selected sources through your claude.ai MCP servers and reports back in that terminal pane. It requires the `mcp_monitor` role terminal (launch via `switchboard.launchMcpMonitorTerminal`). Config is stored machine-globally.
 
 ### Kanban Database
 The board state is persisted in a local SQLite database (`.switchboard/kanban.db`), using `sql.js` (WASM SQLite). When the DB is unavailable, the board falls back to file-derived state from run-sheet events in `.switchboard/sessions/*.json`.
@@ -390,6 +400,12 @@ Manage local research, design system files, and Antigravity Brain artifacts.
 - Update task: `switchboard.clickupUpdateTask`
 - Add comment: `switchboard.clickupAddComment`
 
+**Capabilities beyond import.** ClickUp is a **push-only mirror** — Switchboard pushes state and content *out* to ClickUp but does not poll ClickUp changes back (for two-way remote control, use Linear or Notion). What's supported:
+- **Content push** — local plan edits update the linked ClickUp task description.
+- **Move task between lists** — including status auto-mapping when the source status has no name-match in the target list, and reporting when a task lives in multiple/sprint lists.
+- **Epic round-trip** — importing a ClickUp parent-with-subtasks creates a Switchboard epic + subtasks, and local epics push out as native parent/child ClickUp tasks.
+- **Agent-driven surface** (via skills / LocalApiServer): create/modify tasks, comments, file attachments, and docs/doc-pages.
+
 ### Linear
 - Set API token: `switchboard.setLinearToken` — Token stored in `SecretStorage`
 - Import issues: `switchboard.importFromLinear`
@@ -398,6 +414,14 @@ Manage local research, design system files, and Antigravity Brain artifacts.
 - Update state: `switchboard.linearUpdateState`
 - Add comment: `switchboard.linearAddComment`
 - Update description: `switchboard.linearUpdateDescription`
+
+**Capabilities beyond import.** Unlike ClickUp, Linear is a full two-way provider:
+- **Bidirectional description sync** — editing an issue's description in Linear now flows back into the local plan file automatically (with hash-based loop prevention), not only on the both-sides-changed conflict path.
+- **Status/column sync both directions** via Remote Control polling (see §30).
+- **Move an issue to a different Linear project.**
+- **Epic round-trip** — import a parent-with-subtasks as an epic; push a local epic out as parent/child issues.
+- **Comments + attachments** on top-level issues are captured into the plan body on import.
+- **Archive / unarchive** via the idempotent `issueArchive` / `issueUnarchive` mutations — used by the Auto-Archive Rule (§14) to keep you under Linear's free-tier active-issue cap.
 
 ### Notion
 - Set API token: `switchboard.setNotionToken` — Token stored in `SecretStorage`
@@ -466,6 +490,14 @@ Settings:
 
 ### Searching Archives
 Use the `/archive` IDE chat command to search the DuckDB plan archive.
+
+### Auto-Archive Rule
+A provider-agnostic rule that automatically completes and archives a plan once it has sat in a designated board column past a dwell threshold — handy for keeping a board (and a free-tier Linear workspace) from filling up. Configure it on the Kanban **Setup** tab → *Auto-Archive Rule*:
+- **Enable auto-archive** — checkbox (**off by default**).
+- **Archive-trigger column** — dropdown populated from the live board columns.
+- **Dwell threshold (hours)** — number input (default 2).
+
+When a plan has been in the trigger column longer than the threshold it is moved to Completed, archived locally, and the archive rides the unified push out to Linear/Notion. **Caveat:** the dwell timer uses the plan's `updatedAt` as a proxy for time-in-column, so any edit or comment on the plan resets the clock — a frequently-touched plan may never trip the rule.
 
 ---
 
@@ -1230,7 +1262,7 @@ Per-role prompt customization:
 - **Edit Prompt Template** — Live preview of the composed prompt, editable before dispatch.
 
 **AUTOMATION Tab**
-Automation panel for configuring AUTOBAN rules and timing per column. Includes batch size, complexity filter, routing mode, max sends per terminal, global session cap, and terminal pool management.
+Automation panel for configuring AUTOBAN rules and timing per column. Includes batch size, complexity filter, routing mode, max sends per terminal, global session cap, and terminal pool management. Also hosts the **MCP Monitor** controls (on/off, interval, watched sources, launch status — see §4).
 
 **REMOTE Tab** (Project panel)
 Configure Remote Control — provider (Linear / Notion / ClickUp), boards to sync, remote mode (Ingest / Full), comment-polling and push toggles, silent syncing, and ping frequency. Includes a Sync Health panel. See §30. (This config tab lives in the Project panel; the start/stop toggle is on the Kanban toolbar.)
@@ -1250,7 +1282,7 @@ Board-level configuration:
 
 ### Project Panel (`project.html`)
 
-Hosted by `PlanningPanelProvider` (project mode). Six tabs: KANBAN PLANS, PROJECTS, EPICS, CONSTITUTION, SYSTEM, TUNING.
+Hosted by `PlanningPanelProvider` (project mode). Tabs: KANBAN PLANS, PROJECTS, EPICS, CONSTITUTION, SYSTEM, TUNING, **ARCHITECT**, and **REMOTE** (Remote Control config — see §30).
 
 > Note: Project *creation*, plan-to-project *assignment*, and the **PROJECT CONTEXT** toggle live on the **Kanban panel** (`kanban.html`) board control strip — see its KANBAN tab above — because they act on the board. The per-project **PRD editor** lives on this Project Panel's PROJECTS tab.
 
@@ -1297,6 +1329,15 @@ Adversarial insight extraction and governance tuning:
 - **Refresh** — Reload insight list.
 - **Insight filter** — Filter by status (All / Open / Resolved).
 - Insight list with status management.
+
+**ARCHITECT Tab**
+A guided "Architect Mode" for setting up project **governance** — your PRD, Constitution, System files (`CLAUDE.md` / `AGENTS.md`), and tuning insights. It doesn't add an agent role; it launches a guided session through your existing Planner terminal.
+- **Open Architect Terminal** — Dispatches the Switchboard Architect prompt to the Planner terminal (or spins up an ad-hoc "Switchboard Architect" terminal if no Planner terminal is registered).
+- **Copy Architect Prompt** — Copies the same guided-governance prompt to the clipboard.
+- **Governance-doc sidebar + preview** — Shows which of PRD / Constitution / `CLAUDE.md` / `AGENTS.md` / tuning insights exist, with a clickable preview pane.
+
+**REMOTE Tab**
+Remote Control configuration (provider, boards, mode, push/comment toggles, silent syncing, ping frequency, Sync Health). See §30.
 
 ### Design Panel (`design.html`)
 
@@ -1481,10 +1522,12 @@ The Memo sub-tab also supports direct capture without agent involvement — type
 
 ## 29. Automated Triage Pipeline
 
+> **Not currently exposed (pre-release).** The one-click triage setup — along with the ClickUp/Linear **Kanban Board Mapping** and **Kanban Automation** setup sections — is hidden in the current build while it's being hardened. The underlying functionality (the Ticket Updater agent and triage board) still exists in code, but there is no UI to enable it. The description below documents the intended behavior for when it returns.
+
 One-click setup for auto-pulling bugs from ClickUp or Linear and routing them to the triage agent.
 
 ### Setup
-Setup panel → ClickUp or Linear tab → **"⚡ ENABLE TRIAGE PIPELINE (ONE-CLICK)"**. This creates a "Bug Triage" board with sensible defaults (all editable afterward).
+Setup panel → ClickUp or Linear tab → **"⚡ ENABLE TRIAGE PIPELINE (ONE-CLICK)"**. This creates a "Bug Triage" board with sensible defaults (all editable afterward). *(This control is currently hidden — see the note above.)*
 
 ### Triage Verdict
 The Ticket Updater agent posts a structured verdict as a comment:


### PR DESCRIPTION
Align README, how-to guide, and user manual with the merged Epic 1-7
remote-control program:

- Rename "Linear Remote Control" -> provider-agnostic "Remote Control"
  (Linear / Notion / ClickUp push-only mirror).
- Remove the deleted "ping mode (manual/constant)" control.
- Document Remote mode (Ingest / Full), the push and comment-polling
  toggles, Silent syncing, and the Sync Health panel.
- Document the separate git-native Board State Export channel
  (switchboard.boardStateExport: none | control-plane | wiki).
- Correct config location: REMOTE config tab now lives in the Project
  panel; only the start/stop toggle remains on the Kanban toolbar.
- Update the manual TOC entry, RemoteConfig field list, and §27
  inline references.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LQ1xHtiBcA5RT8t4tFS8Fw