### PR TITLE
Fix /switchboard routing to never implement directly

### DIFF
--- a/.claude/skills/switchboard/SKILL.md
+++ b/.claude/skills/switchboard/SKILL.md
@@ -7,6 +7,10 @@ description: Front door for Switchboard — routes the user's request to the rig
 
 The single entry point. The user describes what they want in plain language and **you** pick the skill — they never have to memorize skill names.
 
+## `/switchboard` never implements
+
+This is a **planning/routing front door** — in a `/switchboard` turn you do NOT write, edit, or suggest code changes, and you do NOT open files to start implementing. Any request to **build, add, change, fix, or implement** something — including imperative asks like *"add a button that…"*, *"this needs to…"*, *"make X do Y"* — routes to **`switchboard-chat`** (planning) unless it matches a more specific skill in the table below. The **plan is the deliverable**; code happens later, via the kanban/coding flow the user chooses. If you catch yourself about to edit a source file from a `/switchboard` turn, stop — you've skipped the routing step.
+
 ## The opener
 
 When the user types a bare `/switchboard` (no request attached), reply with a **short, welcoming prompt** — not a status read-out. Do NOT announce which environment you detected, do NOT list capabilities that are unavailable, do NOT show tables or workflow internals. Just invite them in with a few plain-language examples, e.g.:
@@ -29,7 +33,7 @@ Match the request to a skill and invoke it. Environment detection is silent: che
 
 | The user wants to… | Use |
 | :--- | :--- |
-| Plan / consult on what to build | **`switchboard-chat`** (writes plan files you merge on the branch). If they want Linear/Notion tracking, use the `sw-remote.md` playbook instead. |
+| Plan, consult, or **build / add / change / fix / implement** anything — including imperative asks (*"add a button that…"*, *"this needs to…"*, *"make X do Y"*) | **`switchboard-chat`** (writes plan files you merge on the branch — the plan is the deliverable, not code). If they want Linear/Notion tracking, use the `sw-remote.md` playbook instead. |
 | Capture ideas rapidly, no analysis | **`memo`** ("start memo capture" → `process memo`) |
 | Deepen / adversarially review **one** plan | **`improve-plan`** |
 | Reconcile & restructure an **epic's** subtasks | **`improve-epic`** |

--- a/.switchboard/plans/guided-setup-button-tailored-onboarding.md
+++ b/.switchboard/plans/guided-setup-button-tailored-onboarding.md
@@ -1,0 +1,153 @@
+# Guided Setup Button — State-Aware First-Run Onboarding Prompt
+
+**Plan ID:** 9f3b1c2e-6a44-4d8e-bf21-3c7e2a10d5b8
+
+## Goal
+
+Add a **Guided Setup** button to `implementation.html`, directly beneath the existing
+`Setup` button (`btn-quick-setup`) in the Quick Actions section. When pressed, it copies a
+**tutorial prompt tailored to what the user hasn't done yet** to the clipboard and shows a
+VS Code toast telling them where to paste it.
+
+### The problem
+
+A first-time Switchboard user faces a broad surface (agents, kanban, plans, constitution,
+projects, design, remote control) with no guided on-ramp. The existing `Setup` button opens
+the setup panel but doesn't *teach* — it assumes the user already knows what to configure and
+in what order. There's no single action that says "here's the most important next thing for
+*you*, and here's an agent prompt that will walk you through it."
+
+### Root cause / context
+
+Switchboard's onboarding is spread across the Setup panel, the Kanban board, `project.html`
+(constitution/governance), and the docs (`docs/how_to_use_switchboard.md`,
+`docs/switchboard_user_manual.md`). Nothing inspects the user's *actual* state and points them
+at the single highest-value next step. The result is that new users either over-configure,
+skip the constitution entirely, or never learn the kanban flow.
+
+### The fix (behaviour)
+
+The button inspects three onboarding milestones **in priority order** and generates a prompt
+focused on the **first unmet** one:
+
+1. **No registered terminal agents** → introduce **agent setup** (the most important thing —
+   nothing works without an agent).
+2. **Has agents, but no plans** → teach the **kanban board** and how to create/run plans.
+3. **Has agents + plans, but no constitution** → walk through **`project.html`** to establish
+   project governance.
+4. **All three present** → copy an **"advanced tips"** prompt (epics, `/improve-plan`, design
+   panel, multi-repo control plane, remote control) and a toast confirming they're all set.
+
+The prompt **references the relevant doc paths** and instructs the pasted-into agent to read
+them and walk the user through that one step interactively — it does not embed doc text
+(keeps the clipboard light and always in sync with the docs).
+
+## Detection surfaces (verified in codebase)
+
+All three checks run in the **extension host** (`TaskViewerProvider`), where the state and the
+`vscode` clipboard/toast APIs live — not in the webview.
+
+| Milestone | How to detect | Source |
+| :--- | :--- | :--- |
+| Registered terminal agent | Read the persisted state file via `_resolveStateFilePath()`, parse JSON, check `state.terminals` map is non-empty. This is the same file `_refreshTerminalStatuses()` reads (`src/services/TaskViewerProvider.ts:18653`), so it survives restarts (the in-memory `_registeredTerminals` map does **not** — do not use it). | State file |
+| Plans exist | Enumerate `.switchboard/plans/*.md`, **excluding** internal `brain_*.md` files, and check count > 0. | Workspace fs |
+| Constitution exists | `constitutionUtils.getConstitutionPath(context, workspaceRoot)` + `fs.existsSync`. Honours the user's custom constitution path. | `src/services/constitutionUtils.ts` |
+
+## Implementation steps
+
+### 1. Webview — add the button (`src/webview/implementation.html`)
+
+- After the `btn-quick-setup` button (line ~1517), inside `.quick-actions-section`, add:
+  ```html
+  <button id="btn-guided-setup" class="secondary-btn w-full" style="margin-top: 6px;"
+      title="Copy a tutorial prompt tailored to your next setup step, then paste it into an agent chat">Guided Setup</button>
+  ```
+  (Reuse the exact classes/inline style of the neighbouring Setup button so it matches.)
+
+- Near the existing `btn-quick-setup` listener (line ~1779), add:
+  ```js
+  const btnGuidedSetup = document.getElementById('btn-guided-setup');
+  if (btnGuidedSetup) btnGuidedSetup.addEventListener('click', () => vscode.postMessage({ type: 'guidedSetup' }));
+  ```
+
+The webview does **not** compute the prompt or touch the clipboard — it only posts the message.
+(Clipboard + toast belong in the host, and `navigator.clipboard` is unreliable in the
+sandboxed webview iframe.)
+
+### 2. Extension host — handle the message (`src/services/TaskViewerProvider.ts`)
+
+- In the `onDidReceiveMessage` switch (~line 9029), add `case 'guidedSetup':` that calls a new
+  private method `_handleGuidedSetup()`.
+
+- `_handleGuidedSetup()`:
+  1. Resolve `workspaceRoot` (bail with a toast if none open).
+  2. Run the three detection checks above.
+  3. Pick the first unmet milestone (agents → plans → constitution → all-done).
+  4. Build the tailored prompt (see §3).
+  5. `await vscode.env.clipboard.writeText(prompt)`.
+  6. `vscode.window.showInformationMessage(<paste-instruction toast>)`.
+
+- Reuse existing helpers where present: the state-file read pattern from
+  `_refreshTerminalStatuses`, and `getConstitutionPath` from `constitutionUtils`. Factor the
+  state-file `terminals` read into a small `_hasRegisteredTerminalAgent(): Promise<boolean>`
+  helper if one doesn't already exist, so the check is testable in isolation.
+
+### 3. Prompt templates (reference-by-path)
+
+Four short prompt templates, each naming the doc(s) to read and the step to walk through.
+Suggested doc anchors (confirm section numbers against the live doc when writing):
+
+- **Agents:** `docs/how_to_use_switchboard.md` + `docs/switchboard_user_manual.md` §2
+  (Installation & First-Time Setup), §3 (Agent Roles & Configuration). Mention the `AGENT SETUP`
+  button and registering a terminal agent.
+- **Kanban:** user manual §4 (The AUTOBAN), §17 (Core Workflows). Walk through creating a plan
+  and dragging a card to dispatch it.
+- **Constitution:** user manual §8 (Projects, Epics & Governance) + the Project panel
+  (`project.html`). Walk through establishing a constitution.
+- **Advanced tips (all done):** user manual §5 (Planning Tools), §7 (Multi-Repo Control Plane),
+  §9 (Design Panel), §30 (Remote Control), plus `/improve-plan` and epics.
+
+Each template opens with a line like: *"You are onboarding a Switchboard user. Read
+`<doc paths>`, then walk me through `<step>` interactively — one step at a time, checking I've
+done each before moving on. Focus only on this; don't dump the whole manual."*
+
+### 4. Toast copy
+
+Short, action-oriented, e.g.:
+`Guided setup prompt copied — paste it into your agent chat (Cmd/Ctrl+V) to get walked through <the missing step>.`
+Vary the `<the missing step>` phrase per milestone so the toast reflects what was detected.
+
+## Edge cases & risks
+
+- **No workspace open** → toast "Open a workspace folder to use Guided Setup." No copy.
+- **State file missing/unreadable** → treat as "no agents" (rung 1). Wrap the read in try/catch;
+  never throw out of the click handler.
+- **`brain_*.md` false positives** → must be excluded from the plan count or a fresh install
+  with only internal brain files would skip the kanban tutorial.
+- **Custom constitution path** → always go through `getConstitutionPath`, never hard-code
+  `CONSTITUTION.md`, so users who relocated it aren't told it's missing.
+- **Docs drift** → because we reference paths (not embedded text), section renames only require
+  updating the template strings, not re-syncing copied content. Note the section numbers are a
+  soft dependency — verify against the live manual at implementation time.
+- **No confirmation dialog** anywhere (per repo rule). The button copies immediately.
+
+## Out of scope
+
+- Changing the existing `Setup` button behaviour.
+- Persisting "guided setup dismissed/completed" state or auto-showing on first run — this is a
+  manual, always-available button.
+- Localizing the prompt/toast text.
+
+## Verification
+
+- Manual: with (a) zero agents, (b) agents but no plans, (c) agents+plans but no constitution,
+  (d) all three — click the button and confirm the clipboard payload targets the correct
+  milestone and the toast text matches.
+- Unit: test the milestone-selection function (state inputs → chosen rung) and
+  `_hasRegisteredTerminalAgent` in isolation, per the repo's testing approach (installed VSIX,
+  `src/` as source of truth).
+
+## Metadata
+
+**Complexity:** 4
+**Tags:** feature, frontend, ui, ux

--- a/.switchboard/plans/guided-setup-button-tailored-onboarding.md
+++ b/.switchboard/plans/guided-setup-button-tailored-onboarding.md
@@ -42,6 +42,13 @@ The prompt **references the relevant doc paths** and instructs the pasted-into a
 them and walk the user through that one step interactively — it does not embed doc text
 (keeps the clipboard light and always in sync with the docs).
 
+### Companion changes
+
+- **Remove the old `PLUGIN TUTORIAL` button** in the analyst row of the Agents tab — the new
+  state-aware Guided Setup button supersedes it. (See step 5.)
+- **Add a "Hide Guided Setup button" toggle to `setup.html`** so users who no longer need
+  onboarding can dismiss it. (See step 6.)
+
 ## Detection surfaces (verified in codebase)
 
 All three checks run in the **extension host** (`TaskViewerProvider`), where the state and the
@@ -117,6 +124,43 @@ Short, action-oriented, e.g.:
 `Guided setup prompt copied — paste it into your agent chat (Cmd/Ctrl+V) to get walked through <the missing step>.`
 Vary the `<the missing step>` phrase per milestone so the toast reflects what was detected.
 
+### 5. Remove the old `PLUGIN TUTORIAL` button (`src/webview/implementation.html` + `TaskViewerProvider.ts`)
+
+- Delete the `btn-plugin-tutorial` button construction in `createAnalystRow()`
+  (`implementation.html:3477-3492`) — the whole `tutorialBtn` block through its
+  `container.appendChild(tutorialBtn)`.
+- Remove the now-orphaned `case 'pluginTutorial':` handler in `TaskViewerProvider.ts`
+  (line ~10420) — nothing else posts that message, so it becomes dead code. Confirm no other
+  reference before deleting.
+- **Leave the separate `COPY TUTORIAL PROMPT` button** (`btn-copy-tutorial-prompt`) in
+  `setup.html` untouched — it is a different (clipboard-only) control and out of scope.
+- No migration concern: this removes UI + a message handler, not persisted user state.
+
+### 6. "Hide Guided Setup button" toggle (`src/webview/setup.html` + host + `implementation.html`)
+
+Follow the existing settings pattern used by `julesAutoSyncSetting` / `designSystemDocSetting`
+(persist in host, push to webviews via config-state messages). Recommended as a **global**
+user preference (like `customAgents`' global key), since "no longer need it" is per-user, not
+per-workspace.
+
+1. **setup.html:** add a checkbox in the existing **"Switchboard guide"** section
+   (`setup.html:589-596`), labelled e.g. *"Hide the Guided Setup button in the sidebar"*. On
+   `change`, post `{ type: 'setHideGuidedSetup', enabled }` to the setup panel provider.
+   Initialise its checked state from a `hideGuidedSetupSetting` message on load.
+2. **Host (`TaskViewerProvider` + `SetupPanelProvider`):**
+   - Add `handleSetHideGuidedSetup(enabled)` → persist to globalState key
+     `switchboard.hideGuidedSetup`, and `handleGetHideGuidedSetup(): boolean` (default `false`
+     = visible).
+   - Handle the `setHideGuidedSetup` message in the setup panel's `onDidReceiveMessage`; after
+     saving, refresh both the setup panel (`postSetupPanelState`) and the sidebar
+     (`_postSidebarConfigurationState`).
+   - In `_postSidebarConfigurationState`, post `{ type: 'hideGuidedSetupSetting', enabled }`
+     (mirrors the `designSystemDocSetting` post at `TaskViewerProvider.ts:4515-4520`).
+   - In `postSetupPanelState`, post the same so the checkbox reflects saved state on open.
+3. **implementation.html:** on `hideGuidedSetupSetting`, toggle `#btn-guided-setup`'s
+   visibility (`style.display`). Default visible until a message says otherwise, so nothing
+   flickers on cold boot.
+
 ## Edge cases & risks
 
 - **No workspace open** → toast "Open a workspace folder to use Guided Setup." No copy.
@@ -134,8 +178,9 @@ Vary the `<the missing step>` phrase per milestone so the toast reflects what wa
 ## Out of scope
 
 - Changing the existing `Setup` button behaviour.
-- Persisting "guided setup dismissed/completed" state or auto-showing on first run — this is a
-  manual, always-available button.
+- Auto-showing/dismissing on first run — the button is manual and always-available (except when
+  the user hides it via the setup toggle in step 6).
+- Removing or changing the `COPY TUTORIAL PROMPT` button in `setup.html`.
 - Localizing the prompt/toast text.
 
 ## Verification
@@ -146,8 +191,12 @@ Vary the `<the missing step>` phrase per milestone so the toast reflects what wa
 - Unit: test the milestone-selection function (state inputs → chosen rung) and
   `_hasRegisteredTerminalAgent` in isolation, per the repo's testing approach (installed VSIX,
   `src/` as source of truth).
+- Confirm the analyst-row `PLUGIN TUTORIAL` button is gone and no console error fires from the
+  removed `pluginTutorial` path.
+- Toggle "Hide Guided Setup button" in setup.html → the sidebar button disappears immediately
+  (no reload); untoggle → it returns; setting persists across a window reload.
 
 ## Metadata
 
-**Complexity:** 4
+**Complexity:** 5
 **Tags:** feature, frontend, ui, ux


### PR DESCRIPTION
The switchboard front-door skill had no guardrail preventing the agent
from treating imperative build requests ("add a button that…") as coding
tasks. The routing table's "Plan / consult on what to build" row only
matched when the user explicitly asked to plan, so direct-implementation
phrasing fell through to default coding behavior.

- Add an explicit "never implements" rule: a /switchboard turn routes to
  planning (switchboard-chat) for any build/add/change/fix/implement
  request and never edits source files directly.
- Broaden the routing table's first row to catch imperative asks.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015zWCsxVzg4W8ianzB41he7