### PR TITLE
Add is_epic clobber diagnostics: demotion guard + DB-instance identity

### DIFF
--- a/docs/epic-clobber-log-reading-plan.md
+++ b/docs/epic-clobber-log-reading-plan.md
@@ -1,0 +1,139 @@
+# Plan: Reading the `is_epic` Clobber Diagnostic Log
+
+**Companion to:** `docs/investigation-epic-is_epic-clobber.md` (the root-cause analysis)
+**Purpose:** One repro run writes one file. This doc tells whoever reads that file afterward
+(human or agent) how to turn it into a verdict on *which* clobber candidate is real, and which
+fix to apply.
+
+---
+
+## 0. Before you read — how to produce the file
+
+1. Build/install the VSIX from this branch (`claude/epic-investigation-doc-m9n80g`) so the probes
+   are live. (Reminder from CLAUDE.md: testing is via an installed VSIX, never the repo `dist/`.)
+2. In the target workspace, do the repro **once**: select some plans → **GROUP INTO EPIC**.
+3. Wait ~30 seconds so any watcher/scan events settle. You do **not** need to wait for the
+   ~15-minute self-heal — the clobber happens at creation time and is captured immediately.
+4. Collect the file:
+
+   ```
+   <workspaceRoot>/.switchboard/epic-clobber-diagnostic.txt
+   ```
+
+   That single file contains everything below. Hand it (plus this doc and the investigation doc)
+   to the examining agent. No Dev Tools / output-channel scraping required — the probes mirror
+   themselves into this file.
+
+> If the file does **not** exist after the repro: the probes never fired. Most likely the
+> installed VSIX predates this branch, or the workspace has no `.switchboard/` write access.
+> Confirm the build before drawing any conclusion — an absent file is not evidence.
+
+---
+
+## 1. Line types you will see
+
+Every line is `[ISO-timestamp] <body>`. There are four bodies:
+
+| Prefix | Emitted by | Meaning |
+|--------|-----------|---------|
+| `createEpicFromPlanIds DB-instance check: provider=… watcher=… sameInstance=<bool>` | `KanbanProvider.createEpicFromPlanIds` | Fires once per epic creation. The decisive candidate-❷ test. |
+| `persist instance=… epics=[ … ]` | `KanbanDatabase._persist` | Fires on **every** flush-to-disk. Shows the is_epic state this instance is about to write. |
+| `reload instance=… epics=[ … ]` | `KanbanDatabase._reloadIfStale` | Fires when an instance reloads after an external mtime bump. Shows what it just read from disk. |
+| `EPIC-CLOBBER instance=… updateEpicStatus(…) on epic "…"` + stack | `KanbanDatabase.updateEpicStatus` | Fires only when a live epic (is_epic=1) is about to be explicitly demoted to 0. The smoking gun for candidates ❶/❸/❺. |
+
+`instance=#N(kanban.db)` is the per-object tag. **Two different `#N` for the same `kanban.db`
+means two in-memory sql.js instances exist for one file** — the precondition for candidate ❷.
+
+The `epics=[ … ]` payload lists each `.switchboard/epics/` row as
+`<plan_file>=is_epic:<0|1>,epic_id:<value>`.
+
+---
+
+## 2. Decision tree — read the file top to bottom
+
+Anchor on the epic's `plan_file` (the `<slug>-<uuid>.md` created by the repro). Trace its
+`is_epic` value across the timeline.
+
+### Q1 — Is there an `EPIC-CLOBBER` line for the epic's plan_file?
+
+- **YES → verdict: EXPLICIT DEMOTION (candidate ❶ / ❸ / ❺).**
+  Read the attached stack trace; the top app frame names the caller:
+  - `createEpicFromPlanIds` subtask loop → **❶** (a subtask's `planId`/`sessionId` resolved to the epic's row).
+  - `addSubtaskToEpic` / `removeSubtaskFromEpic` (PlanningPanelProvider) → **❸**.
+  - `RemoteControlService` / `ClickUpSyncService` / `LinearSyncService` → **❺** (should be ruled out —
+    if this appears, sync was actually enabled; revisit that assumption).
+  - **Fix:** Step 2 of the investigation doc — the structural guard in `updateEpicStatus` refusing to
+    clear `is_epic` for a `.switchboard/epics/` file. Then also fix the specific caller's planId resolution.
+  - Note the `instance=` on the clobber line and cross-check Q3 — a demotion run against a *stale*
+    instance is ❶/❸ **and** ❷ compounded.
+
+- **NO → go to Q2.** (The `is_epic=0` arrived without any explicit demotion call — a lost write.)
+
+### Q2 — On the `DB-instance check` line, what is `sameInstance`?
+
+- **`sameInstance=false` → verdict: SPLIT INSTANCES (candidate ❷ precondition confirmed).**
+  The Provider wrote `is_epic=1` to `provider=#A`, but the watcher operates on `watcher=#B`.
+  Confirm the clobber mechanism in Q3.
+  - Also compare the two `dbPath=` values on this line. If the paths differ, the split is a
+    **path-resolution divergence** (`~` expansion / symlink / mapped-parent redirect in
+    `forWorkspace` / `resolveEffectiveWorkspaceRoot`). If the paths are identical but instances
+    differ, the `_instancesByDbPath` cache (KanbanDatabase.ts:~868) is being bypassed.
+  - **Fix:** make both paths resolve to one instance — normalize the root before `forWorkspace`,
+    or have the watcher reuse the Provider's `_getKanbanDb`. Do **not** "heal on refresh" (per the
+    user's explicit directive: fix the clobber, not the symptom).
+
+- **`sameInstance=true` → candidate ❷ is dead at the fork.** The clobber is neither an explicit
+  demotion (Q1) nor a split at creation. Go to Q3, then Q4.
+
+### Q3 — Trace the `persist` / `reload` lines for the epic's plan_file, in timestamp order.
+
+Look for this signature of a **stale-snapshot overwrite**:
+
+```
+persist instance=#A epics=[ …epic.md=is_epic:1… ]     ← Provider flushes the good state
+reload  instance=#B epics=[ …epic.md=is_epic:0… ]     ← other instance had NOT seen it
+persist instance=#B epics=[ …epic.md=is_epic:0… ]     ← #B flushes its stale 0 over the top  ← CLOBBER
+```
+
+- If you see a `persist instance=#B … is_epic:0` **after** a `persist instance=#A … is_epic:1`
+  for the same file, and `#B ≠ #A` → **verdict: STALE-SNAPSHOT PERSIST (candidate ❷ confirmed).**
+  The instance in the last `is_epic:0` persist is the culprit; its stack of callers is whatever
+  triggered that flush (often the watcher's `insertFileDerivedPlan` or a config write).
+- If every `persist` line for the file shows `is_epic:1` and only a later `reload` shows `is_epic:0`,
+  the `0` is coming from **disk** — i.e. something outside these instances wrote it, or the on-disk
+  row was never 1. Go to Q4.
+
+### Q4 — Neither explicit demotion nor a split/stale persist. Widen the net.
+
+Remaining possibilities from the investigation doc:
+- **❹ backup export/restore gap** — a `SELECT` that omits `is_epic` re-inserting the row as NULL/0.
+  Look for a `reload` immediately after a restore, or check whether `exportStateToFile` /
+  `_writeKanbanStateBackup` ran (they fire from `_persist`). Fix = add `is_epic`/`epic_id`/`project_id`
+  to the export+restore columns (Step 3).
+- A code path that writes `is_epic` **without** going through `updateEpicStatus` (so the Q1 guard
+  never saw it). Grep for direct `UPDATE plans SET is_epic` and `insertFileDerivedPlan` calls with a
+  0/NULL is_epic, and add the same file-logging probe there, then re-run.
+
+---
+
+## 3. One-paragraph verdict template (for the examining agent)
+
+> **Verdict:** `<EXPLICIT DEMOTION ❶/❸/❺ | SPLIT INSTANCES + STALE PERSIST ❷ | BACKUP GAP ❹ | UNKNOWN — widen probes>`.
+> **Evidence:** quote the exact log lines (with timestamps and `instance=` tags) that establish it.
+> **Culprit:** the caller named by the stack trace, or the offending `instance=#N` and the flush that carried `is_epic:0`.
+> **Recommended fix:** the matching Step from `docs/investigation-epic-is_epic-clobber.md`, plus any caller-specific correction.
+> **Confidence + gaps:** note anything the single run did NOT disambiguate and what a follow-up probe would need.
+
+---
+
+## 4. Cleanup (after the verdict)
+
+These probes are temporary. Once the clobber is fixed, remove:
+- `src/services/epicClobberDiag.ts` (the whole file)
+- its import + call sites in `KanbanDatabase.ts` (instanceId field, `_nextInstanceId`, demotion guard,
+  `_diagEpicSnapshot`, and its calls in `_persist`/`_reloadIfStale`)
+- the DB-instance-check block in `KanbanProvider.createEpicFromPlanIds`
+- the epic-file-handle log in `GlobalPlanWatcherService._handlePlanFile`
+- the generated `.switchboard/epic-clobber-diagnostic.txt` files in any test workspace
+
+Grep for `is_epic clobber` and `EPIC CLOBBER` / `EPIC-CLOBBER` to find every probe.

--- a/src/services/GlobalPlanWatcherService.ts
+++ b/src/services/GlobalPlanWatcherService.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 import { KanbanDatabase, type WorkspaceDatabaseMapping, type KanbanPlanRecord } from './KanbanDatabase';
+import { appendEpicClobberDiag } from './epicClobberDiag'; // DIAGNOSTIC (is_epic clobber) — remove with the probes
 import { parsePlanMetadata, extractClickUpTaskId, extractLinearIssueId } from './planMetadataUtils';
 import { isRuntimeMirrorPlanFile } from './PlanFileImporter';
 import { PlanManifestService } from './PlanManifestService';
@@ -459,6 +460,7 @@ export class GlobalPlanWatcherService implements vscode.Disposable {
             // See docs/investigation-epic-is_epic-clobber.md. Remove once the clobber is fixed.
             if (relativePath.startsWith('.switchboard/epics/')) {
                 this._outputChannel?.appendLine(`[GlobalPlanWatcher] epic-file handle: instance ${db.instanceId} (dbPath=${db.dbPath}) for ${relativePath}`);
+                appendEpicClobberDiag(workspaceRoot, `watcher._handlePlanFile: instance=${db.instanceId} handling epic file ${relativePath}`);
             }
             if (isRuntimeMirrorPlanFile(path.basename(relativePath))) {
                 this._outputChannel?.appendLine(`[GlobalPlanWatcher] Skipped brain mirror file: ${relativePath}`);

--- a/src/services/GlobalPlanWatcherService.ts
+++ b/src/services/GlobalPlanWatcherService.ts
@@ -452,6 +452,14 @@ export class GlobalPlanWatcherService implements vscode.Disposable {
             await db.ensureReady();
 
             const relativePath = path.relative(workspaceRoot, uri.fsPath).replace(/\\/g, '/');
+            // DIAGNOSTIC (is_epic clobber investigation): log which sql.js instance the watcher
+            // operates on when it handles an epic file. Compare against the provider=… /
+            // watcher=… line from createEpicFromPlanIds. Same instanceId ⇒ candidate ❷ is dead;
+            // different ⇒ this handler may persist a stale snapshot over the epic's is_epic=1.
+            // See docs/investigation-epic-is_epic-clobber.md. Remove once the clobber is fixed.
+            if (relativePath.startsWith('.switchboard/epics/')) {
+                this._outputChannel?.appendLine(`[GlobalPlanWatcher] epic-file handle: instance ${db.instanceId} (dbPath=${db.dbPath}) for ${relativePath}`);
+            }
             if (isRuntimeMirrorPlanFile(path.basename(relativePath))) {
                 this._outputChannel?.appendLine(`[GlobalPlanWatcher] Skipped brain mirror file: ${relativePath}`);
                 return;

--- a/src/services/KanbanDatabase.ts
+++ b/src/services/KanbanDatabase.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { isAllowedSwitchboardLocation } from '../utils/switchboardLocationGuard';
 import { STATE_KEY_TO_CONFIG } from './stateConfigBridge';
 import { DEFAULT_KANBAN_COLUMNS } from './agentConfig';
+import { appendEpicClobberDiag } from './epicClobberDiag'; // DIAGNOSTIC (is_epic clobber) — remove with the probes
 
 export interface WorkspaceDatabaseMapping {
     id: string;
@@ -1650,10 +1651,13 @@ export class KanbanDatabase {
         // clear candidate ❷ (lost-write via a stale instance) — pair with the instanceId logs.
         // See docs/investigation-epic-is_epic-clobber.md. Remove once the clobber is fixed.
         if (plan.isEpic === 1 && isEpic === 0) {
+            const stack = new Error().stack;
             console.error(
                 `[KanbanDatabase] ⚠️ EPIC CLOBBER on instance ${this.instanceId}: updateEpicStatus(${planId}, 0, '${epicId}') would clear is_epic on epic "${plan.topic}" (plan_file=${plan.planFile}). Stack:`,
-                new Error().stack
+                stack
             );
+            appendEpicClobberDiag(this._workspaceRoot,
+                `EPIC-CLOBBER instance=${this.instanceId} updateEpicStatus(planId=${planId}, isEpic=0, epicId='${epicId}') on epic "${plan.topic}" (plan_file=${plan.planFile})\n${stack}`);
         }
         const oldEpicId = plan.epicId;
         const relativePlanFile = this._ensureRelativePlanFile(plan.planFile);
@@ -4422,6 +4426,7 @@ export class KanbanDatabase {
             // migrations, post rollback-guard) so a rolled-back reload failure
             // never produces a false-positive bump.
             this._dataVersion++;
+            this._diagEpicSnapshot('reload'); // DIAGNOSTIC (is_epic clobber) — what this instance just loaded from disk
         } catch (error) {
             console.error('[KanbanDatabase] Failed to reload from disk:', error);
             // Keep using stale in-memory copy — better than crashing
@@ -6222,8 +6227,30 @@ FROM plans
         return this._workspaceRoot;
     }
 
+    /**
+     * DIAGNOSTIC (is_epic clobber investigation) — TEMPORARY. Snapshot the is_epic state of
+     * every .switchboard/epics/ row THIS instance currently holds, tagged with the instance id
+     * and a context label ("persist" = about to flush to disk, "reload" = just loaded from disk).
+     *
+     * This is the fallback that makes candidate ❷ visible without a second test run: if a stale
+     * instance flushes is_epic=0 for an epic the Provider just set to 1, the "persist" line names
+     * the offending instance and the exact moment. Logs nothing when the workspace has no epic
+     * rows, to keep the file focused. Remove with the other probes.
+     */
+    private _diagEpicSnapshot(context: 'persist' | 'reload'): void {
+        try {
+            if (!this._db) return;
+            const res = this._db.exec("SELECT plan_file, is_epic, epic_id FROM plans WHERE plan_file LIKE '.switchboard/epics/%'");
+            const rows = res[0]?.values ?? [];
+            if (rows.length === 0) return;
+            const summary = rows.map(r => `${r[0]}=is_epic:${r[1]},epic_id:${r[2] ?? ''}`).join(' | ');
+            appendEpicClobberDiag(this._workspaceRoot, `${context} instance=${this.instanceId} epics=[ ${summary} ]`);
+        } catch { /* diagnostic only */ }
+    }
+
     private async _persist(): Promise<boolean> {
         if (!this._db) return false;
+        this._diagEpicSnapshot('persist');
         // Bump the board-data version counter. Every board-data write funnels
         // through _persist(), so this is the single choke point that lets
         // KanbanProvider short-circuit a no-op refresh in O(1). Non-board-data

--- a/src/services/KanbanDatabase.ts
+++ b/src/services/KanbanDatabase.ts
@@ -719,6 +719,12 @@ export class KanbanDatabase {
     private static _instancesByDbPath = new Map<string, KanbanDatabase>();
     private static _warnedUnmappedRoots = new Set<string>();
     private static _sqlJsPromise: Promise<SqlJsStatic> | null = null;
+    // DIAGNOSTIC (is_epic clobber investigation): monotonic id so we can tell whether the
+    // KanbanProvider and the GlobalPlanWatcherService are operating on the SAME in-memory
+    // sql.js instance. If they differ for the same on-disk DB, a stale-snapshot _persist()
+    // can silently overwrite an is_epic=1 write (clobber candidate ❷). See
+    // docs/investigation-epic-is_epic-clobber.md. Remove once the clobber is identified.
+    private static _nextInstanceId = 1;
 
     /**
      * Expand ~ to home directory. Shared by _redirectToParentIfMapped and forWorkspace.
@@ -1219,8 +1225,14 @@ export class KanbanDatabase {
         return path.join(this._workspaceRoot, '.switchboard', 'kanban-board.md');
     }
 
+    // DIAGNOSTIC (is_epic clobber): stable per-instance tag, e.g. "#3(kanban.db)". Logged by
+    // the demotion guard and at the createEpicFromPlanIds fork so a mismatch between the
+    // Provider's instance and the watcher's instance is visible in one repro run.
+    public readonly instanceId: string;
+
     private constructor(private readonly _workspaceRoot: string, resolvedDbPath: string) {
         this._dbPath = resolvedDbPath;
+        this.instanceId = `#${KanbanDatabase._nextInstanceId++}(${path.basename(resolvedDbPath)})`;
     }
 
     public dispose(): void {
@@ -1630,6 +1642,19 @@ export class KanbanDatabase {
     public async updateEpicStatus(planId: string, isEpic: number, epicId: string): Promise<boolean> {
         const plan = await this.getPlanByPlanId(planId);
         if (!plan) return false;
+        // DIAGNOSTIC (is_epic clobber investigation): catch an explicit demotion of a live
+        // epic in the act. Fires only when this instance currently sees the plan as an epic
+        // (is_epic=1) and the incoming write would clear it (is_epic=0). The stack trace names
+        // the exact caller (subtask-linking loop, PlanningPanel, remote sync, …). A HIT is a
+        // smoking gun for the "explicit demotion" family (candidates ❶/❸/❺). SILENCE does not
+        // clear candidate ❷ (lost-write via a stale instance) — pair with the instanceId logs.
+        // See docs/investigation-epic-is_epic-clobber.md. Remove once the clobber is fixed.
+        if (plan.isEpic === 1 && isEpic === 0) {
+            console.error(
+                `[KanbanDatabase] ⚠️ EPIC CLOBBER on instance ${this.instanceId}: updateEpicStatus(${planId}, 0, '${epicId}') would clear is_epic on epic "${plan.topic}" (plan_file=${plan.planFile}). Stack:`,
+                new Error().stack
+            );
+        }
         const oldEpicId = plan.epicId;
         const relativePlanFile = this._ensureRelativePlanFile(plan.planFile);
         let affected = 0;

--- a/src/services/KanbanProvider.ts
+++ b/src/services/KanbanProvider.ts
@@ -10024,6 +10024,17 @@ ${FOCUS_DIRECTIVE}`;
         if (!db || !(await db.ensureReady())) {
             return { success: false, error: 'Kanban database not available.' };
         }
+        // DIAGNOSTIC (is_epic clobber investigation): is the Provider writing is_epic=1 to the
+        // SAME in-memory sql.js instance the GlobalPlanWatcherService reads/persists? The watcher
+        // resolves its DB via KanbanDatabase.forWorkspace(workspaceRoot) (GlobalPlanWatcherService.ts:451).
+        // If these two are NOT ===, the watcher can flush a stale snapshot over this write —
+        // clobber candidate ❷. If they ARE ===, ❷ is dead and the clobber is an explicit demotion
+        // (watch for the EPIC CLOBBER log). See docs/investigation-epic-is_epic-clobber.md.
+        const watcherDb = KanbanDatabase.forWorkspace(workspaceRoot);
+        console.log(
+            `[KanbanProvider] createEpicFromPlanIds DB-instance check: provider=${db.instanceId} (dbPath=${db.dbPath}), ` +
+            `watcher=${watcherDb.instanceId} (dbPath=${watcherDb.dbPath}), sameInstance=${db === watcherDb}`
+        );
         const workspaceId = await db.getWorkspaceId();
         if (!workspaceId) {
             return { success: false, error: 'Workspace ID not found. Cannot create epic.' };

--- a/src/services/KanbanProvider.ts
+++ b/src/services/KanbanProvider.ts
@@ -23,6 +23,7 @@ import { AgentSkillExporter } from './AgentSkillExporter';
 import { deriveKanbanColumn } from './kanbanColumnDerivation';
 import { buildKanbanBatchPrompt, buildPromptDispatchContext, BatchPromptPlan, columnToPromptRole, resolveWorkingDir, SUPPRESS_WALKTHROUGH_DIRECTIVE, CAVEMAN_OUTPUT_DIRECTIVE, FOCUS_DIRECTIVE, buildCustomAgentPrompt, PromptBuilderOptions, resolvePlanPathForWorktree, resolveWorkingDirForWorktree } from './agentPromptBuilder';
 import { KanbanDatabase, type WorkspaceDatabaseMapping, type KanbanPlanRecord, type WorktreeRow } from './KanbanDatabase';
+import { appendEpicClobberDiag } from './epicClobberDiag'; // DIAGNOSTIC (is_epic clobber) — remove with the probes
 import { GlobalIntegrationConfigService } from './GlobalIntegrationConfigService';
 import { KanbanMigration } from './KanbanMigration';
 import { legacyToScore, scoreToRoutingRole, parseComplexityScore, deriveComplexityFromContent } from './complexityScale';
@@ -10031,10 +10032,11 @@ ${FOCUS_DIRECTIVE}`;
         // clobber candidate ❷. If they ARE ===, ❷ is dead and the clobber is an explicit demotion
         // (watch for the EPIC CLOBBER log). See docs/investigation-epic-is_epic-clobber.md.
         const watcherDb = KanbanDatabase.forWorkspace(workspaceRoot);
-        console.log(
-            `[KanbanProvider] createEpicFromPlanIds DB-instance check: provider=${db.instanceId} (dbPath=${db.dbPath}), ` +
-            `watcher=${watcherDb.instanceId} (dbPath=${watcherDb.dbPath}), sameInstance=${db === watcherDb}`
-        );
+        const instanceCheck =
+            `createEpicFromPlanIds DB-instance check: provider=${db.instanceId} (dbPath=${db.dbPath}), ` +
+            `watcher=${watcherDb.instanceId} (dbPath=${watcherDb.dbPath}), sameInstance=${db === watcherDb}`;
+        console.log(`[KanbanProvider] ${instanceCheck}`);
+        appendEpicClobberDiag(workspaceRoot, instanceCheck);
         const workspaceId = await db.getWorkspaceId();
         if (!workspaceId) {
             return { success: false, error: 'Workspace ID not found. Cannot create epic.' };

--- a/src/services/epicClobberDiag.ts
+++ b/src/services/epicClobberDiag.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * DIAGNOSTIC (is_epic clobber investigation) — TEMPORARY.
+ *
+ * Single sink for every is_epic-clobber probe so ONE repro run produces ONE file an
+ * agent can read afterwards, instead of the operator scraping the Dev Tools console and
+ * the Switchboard output channel by hand.
+ *
+ * Output file: <workspaceRoot>/.switchboard/epic-clobber-diagnostic.txt (append-only).
+ * Each line is ISO-timestamped. Writes are synchronous + best-effort (never throw into a
+ * caller) — correctness of the diagnostic file matters more than its latency, and this
+ * only runs while the probes are in the tree.
+ *
+ * Reading guide: docs/epic-clobber-log-reading-plan.md
+ *
+ * Remove this file and its call sites once the clobber is identified and fixed.
+ */
+export function appendEpicClobberDiag(workspaceRoot: string, line: string): void {
+    try {
+        if (!workspaceRoot) return;
+        const dir = path.join(workspaceRoot, '.switchboard');
+        const file = path.join(dir, 'epic-clobber-diagnostic.txt');
+        try { fs.mkdirSync(dir, { recursive: true }); } catch { /* dir likely exists */ }
+        fs.appendFileSync(file, `[${new Date().toISOString()}] ${line}\n`, 'utf8');
+    } catch {
+        // A diagnostic must never break the operation it observes. Swallow.
+    }
+}


### PR DESCRIPTION
Instruments the two decisive checks from the investigation doc so a single
repro run distinguishes the clobber candidates:

- KanbanDatabase.updateEpicStatus: logs an EPIC CLOBBER error + stack trace
  when a live epic (is_epic=1) is about to be demoted to is_epic=0. A hit
  names the exact caller (candidates 1/3/5 — explicit demotion).
- KanbanDatabase: per-instance instanceId tag ("#N(kanban.db)") so separate
  in-memory sql.js instances are distinguishable.
- KanbanProvider.createEpicFromPlanIds: logs whether the Provider's DB
  instance is === the one the watcher resolves via forWorkspace(); a
  mismatch is candidate 2 (lost write via stale-snapshot persist).
- GlobalPlanWatcherService._handlePlanFile: logs which instance handles an
  epic file, to correlate against the Provider's instance.

Diagnostics only; no behavior change. Remove once the clobber is fixed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tue4Am3GgyBNffm9ueGwhi