### PR TITLE
Dev Docs: agent-assist prompts plan

### DIFF
--- a/.switchboard/plans/dev-docs-agent-prompts.md
+++ b/.switchboard/plans/dev-docs-agent-prompts.md
@@ -1,0 +1,70 @@
+# Dev Docs — Agent-Assist Prompts
+
+**Plan ID:** 8b1e4d90-6c2a-47f3-a5e1-2d9f0c7b3a11
+
+## Goal
+
+Define the "Draft/Improve with agent" prompts for the Dev Docs tab (fix 4 of the Dev Docs in-place fixes) and how they are wired in. This is the authoring hand-off: a per-doc button copies a ready-to-paste prompt to the clipboard so an agent can write or improve the doc and write it back to disk.
+
+### Problem & background
+
+The Dev Docs tab has no way to ask an agent for help writing a doc. Switchboard already has ~15 "copy prompt → paste into agent" hand-offs (e.g. refine-ticket at `PlanningPanelProvider.ts:6197`, tuning at `:7098`), all following the same shape: *"You are …"* → `##` context sections → write-to-path instruction → *"report back"*. These prompts adopt that house style so the behaviour is consistent with the rest of the extension.
+
+## The prompts
+
+Two variants, chosen by whether the selected doc already has content.
+
+### Draft — new / empty doc
+
+```
+You are writing a developer document for the project at <workspaceRoot>.
+
+## Document
+- **Title:** <title>
+- **Type:** <Docs | README | Wiki>
+- **File path (write the finished doc here):** <docPath>
+
+The file is currently empty (or contains only a title heading). Research the
+codebase as needed to write an accurate, useful developer doc for this topic.
+Write the finished markdown directly to the file path above. Report back with a
+short summary of what you covered.
+```
+
+### Improve — existing doc
+
+```
+You are improving an existing developer document for the project at <workspaceRoot>.
+
+## Document
+- **Title:** <title>
+- **Type:** <Docs | README | Wiki>
+- **File path (write the improved doc back here):** <docPath>
+
+## Current content
+<current markdown>
+
+Read the current content above and the relevant parts of the codebase. Fill
+gaps, correct anything out of date, and improve clarity and structure without
+discarding accurate existing material. Write the improved markdown back to the
+file path, preserving any YAML frontmatter. Report back with a summary of what
+you changed.
+```
+
+## Wiring
+
+- Add a per-doc strip button (e.g. "Draft with agent" / "Improve with agent", label toggled by whether the doc has content) to the Dev Docs controls strip (`planning.html:3825`).
+- On click, the webview posts a message with the selected doc's path; the backend builds the appropriate prompt and calls `vscode.env.clipboard.writeText(prompt)` + `showTemporaryNotification(...)`, mirroring the refine flow (`PlanningPanelProvider.ts:6211-6212`).
+- The `<Type>` token is the source type from the fix-3 dropdown (README / Docs / Wiki).
+- All source types are writable (git-backed sources write via their clone + commit/push), so the button applies to every type — no read-only exclusion.
+
+## Edge cases
+
+- **Large docs:** the Improve prompt inlines current content; apply the same 200 KB guard already used by clipboard import (`PlanningPanelProvider.ts:8648`) so the clipboard payload stays sane.
+- **No doc selected:** the button is disabled until a doc is selected (same gating as Edit/Delete).
+- **YAML frontmatter:** the Improve prompt explicitly tells the agent to preserve frontmatter, matching the refine-ticket instruction.
+
+## Metadata
+
+**Complexity:** 2
+**Tags:** frontend, ux, agent-assist
+**Repo:** switchboard

--- a/.switchboard/plans/dev-docs-tab-in-place-fixes.md
+++ b/.switchboard/plans/dev-docs-tab-in-place-fixes.md
@@ -39,7 +39,7 @@ Dev Docs was built as a minimal owned CRUD store and never inherited the afforda
 The tab's primary navigation becomes a **source-type dropdown** in the controls strip (`planning.html:3825`), modeled on the Docs tab's `docs-source-filter` (`planning.html:3561`). Selecting a type scopes the list pane to that source:
 - **Docs** — the configurable `docs/` folder from fix 2 (the default/authoring source; create + edit + import here).
 - **README** — the workspace root `README.md` (case-insensitive), surfaced as a first-class editable entry with its own badge in `renderDevDocsList` (`planning.js:10730`). `_resolveDevDocPath` gains a narrow allowance for exactly `<root>/README.md`.
-- **Wiki** — git wiki (see fix 5; deferred / read-only to start).
+- **Wiki** — git wiki (see fix 5; writable via its git clone, commit/push on save).
 - Extensible: the dropdown enum is the single place new source types (Pages, sibling repo) are added.
 - `projectContextSync.ts` includes README + the docs folder in the bundle, each labeled by type.
 
@@ -49,7 +49,8 @@ The tab's primary navigation becomes a **source-type dropdown** in the controls 
 ### 5. Git-backed sources (surfaced through the fix-3 dropdown)
 Each git source is a **type in the dropdown** (fix 3), not a separate UI:
 - **5a (local, cheap):** in-repo `docs/` (fix 2) and README (fix 3) already cover the common cases. Add sibling-repo/bench folders on disk as additional selectable sources.
-- **5b (remote, deferred):** **Wiki** and git Pages / other remote repo as read-only fetched snapshots, clearly marked read-only. Borrow the Docs tab's multi-source model rather than rebuilding it. Gate behind 5a landing.
+- **5b (remote, deferred):** **Wiki**, git Pages, and other remote repos — **all writable**. The source is a local clone; save = write file → commit → push. Deferred only for the clone/fetch + auth plumbing, not because they're read-only. Borrow the Docs tab's multi-source model rather than rebuilding it. Gate behind 5a landing.
+  - Write path per type: wiki → `<repo>.wiki.git` clone; Pages → the serving branch (`gh-pages`) or `/docs` folder; other repo → its own working clone.
 
 ### 6. Clipboard import
 - Add an "Import" button to the Dev Docs controls strip (`planning.html:3825`) → posts `importDevDocFromClipboard` → backend reuses `_handleImportResearchDoc` logic (`:8634`) targeting the resolved devdocs folder (H1-derived title, 200 KB cap already present).
@@ -57,7 +58,8 @@ Each git source is a **type in the dropdown** (fix 3), not a separate UI:
 ## Edge cases & migration
 
 - **No migration — clean break.** The Dev Docs feature is unreleased, so `.switchboard/devdocs/` is simply replaced by the configurable `docs/` default. No dual-read, no `*.migrated.bak`, no compat shim (per house rules, unreleased dev work takes clean breaks).
-- **README is a tracked repo file** — editing it writes real source. The path-guard allowance must be exactly `<root>/README.md`, nothing broader, to keep the traversal protection intact. Read-only remote sources (Wiki/Pages) must never be writable through the editor.
+- **README is a tracked repo file** — editing it writes real source. The path-guard allowance must be exactly `<root>/README.md`, nothing broader, to keep the traversal protection intact.
+- **Git-backed sources are writable, but saving involves commit + push** — network and auth can fail mid-save. Surface push failures clearly and don't lose the user's edit (the local clone keeps the committed change even if push fails; a retry re-pushes). No silent data loss.
 - **Empty `docs/`** — a fresh workspace may have no `docs/` folder; `_listDevDocs` handles a missing dir (already does via try/catch at `:8748`), and create (`:2537`) makes it with `mkdir -p`.
 - **No confirmation dialogs** (house rule); `window.confirm()` is a silent no-op in the webview. Delete stays immediate.
 - Verify external-change handling (`planning.js:3882`, `externalChangePending.devdocs`) still fires for README and the new default location.


### PR DESCRIPTION
## Summary

Planning docs for the Dev Docs tab work:

- **`dev-docs-agent-prompts.md`** (new) — defines the "Draft/Improve with agent" prompts for the Dev Docs tab and how the per-doc button wires them to the clipboard, following the existing refine-ticket prompt style. Includes both variants (Draft for empty docs, Improve for existing), wiring notes, and edge cases (200 KB guard, disabled-when-none-selected, frontmatter preservation).
- **`dev-docs-tab-in-place-fixes.md`** (correction) — updates the git-backed sources section so Wiki/Pages/remote repos are treated as writable (commit/push on save) rather than read-only.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)