### PR TITLE
Add Orchestration automation mode feature + subtask plans

### DIFF
--- a/.switchboard/features/orchestration-automation-mode-b4c8934e-ff8a-4986-939d-5310b1c16e9a.md
+++ b/.switchboard/features/orchestration-automation-mode-b4c8934e-ff8a-4986-939d-5310b1c16e9a.md
@@ -1,0 +1,77 @@
+---
+description: 'Orchestration Automation Mode — unattended coding + code-review batching via a system-woken orchestrator'
+---
+
+# Orchestration Automation Mode
+
+**Complexity:** 8
+**Tags:** backend, feature, automation, ui
+**Project:** Switchboard
+
+## Goal
+
+Add a fourth kanban automation mode — **Orchestration** — that runs a batch of work through the coding and code-review stages unattended, managed by an **orchestrator agent** that the *system* wakes on a fixed interval (never self-scheduling). The user picks Orchestration in the AUTOMATION tab, presses Start, and the orchestrator batches every eligible plan into features, fans the work out across per-feature worktrees and terminals, then sleeps. On each interval tick the system wakes it to check progress, triage agent requests, and advance or merge work — feature by feature — until the batch is done.
+
+### Problem / background / root cause
+
+Switchboard already automates dispatch, but only **reactively and per-card**: the autoban engine (`src/services/autobanState.ts`, modes `single-column | multi-column | antigravity-batch`) fires a column's agent as cards move, and `PipelineOrchestrator` advances one plan per tick. Neither expresses *managed batch execution* — "take everything in Plan Reviewed, code it, review it, and merge it back, coordinating across many worktrees." There is no actor that groups loose work, fans it out with a concurrency ceiling, verifies completion against ground truth, handles agent questions, and drives merges to conclusion. Today a human does that choreography by hand: grouping plans, creating worktrees, dispatching each terminal, checking in, and merging branch by branch.
+
+The insight that makes this cheap to build: **almost every primitive already exists.** The autoban engine already has an interval tick with `lastTickAt` tracking (the wake mechanism), `group-into-features` already clusters loose plans into features, the worktree system already auto-creates per-feature integration/subtask worktrees and terminals, and the `merge-prompt` design already defines agent-driven, conflict-resolving merges (subtask → integration → main). What is missing is (a) a mode that wires these together, (b) one new comms primitive — a file-based agent→orchestrator request channel plus a session log — and (c) an orchestrator persona. The orchestrator operates the board through the same LocalApiServer operations a human clicks, and it trusts **git/board state**, not agent self-report, as the signal of truth.
+
+**Scope discipline:** Orchestration automates **coding and code review only**. Planning stays human-in-the-loop — most agent questions/warnings/research needs arise at the planner stage, and those escalate to the human rather than being auto-resolved. If a user wants a planning pass or a curated grouping first, they do it manually before starting automation.
+
+## Design overview
+
+Orchestration is a new `automationMode: 'orchestration'` on the existing autoban engine, plus a small comms layer and an orchestrator workflow.
+
+**Flow:**
+1. **Select mode** — the AUTOMATION tab gains an *Orchestration* option and a **Start orchestrator** button. Selecting the mode **auto-enables worktree-per-feature** (`feature_worktree_mode`), because per-feature worktrees are the unit of parallelism and the merge topology.
+2. **Start → batch** — the orchestrator terminal launches and runs the existing `group-into-features` skill with the **confirm gate disabled** (unattended). Unlike the interactive skill, it also sweeps every remaining standalone plan into a single **`Miscellaneous`** feature, so nothing is left ungrouped. The system auto-creates each feature's worktrees and terminals.
+3. **Fan out** — the orchestrator dispatches each feature's subtasks into their terminals by stage (code → code review), then **sleeps**. It does not hold the fleet in-context.
+4. **Wake + triage** — on each interval tick the *system* wakes the orchestrator. It reads the agent request inbox, **verifies real progress against git and board state**, writes a triage summary to the session log, and acts: advance a subtask to the next stage, dispatch a research agent for a well-formed request, escalate a planner-stage question to the human, or — when a feature's subtasks are coded and reviewed — run the **merge-back**.
+5. **Merge back (feature by feature)** — the orchestrator merges each feature's branches and resolves conflicts as it goes, following the agent-driven merge pattern (subtask → feature integration branch → main). One feature at a time keeps conflicts contained; the orchestrator is the agent that resolves them.
+6. **Done** — when all features are merged (or escalated), the batch is complete and the orchestrator reports out.
+
+**Reused, not built:** autoban interval tick + `lastTickAt` (`autobanState.ts`); `group-into-features` skill; worktree auto-creation + kind-aware merge targets; the `merge-prompt`/`worktree_cleanup` agent-driven merge pattern; LocalApiServer board ops (`/kanban/move`, `/kanban/feature/*`); terminal dispatch.
+
+**Newly built:** the `'orchestration'` mode + its config/UI + worktree-mode coupling; the file-based agent→orchestrator request inbox + session log; the orchestrator persona workflow; the batch-level fan-out/verify/merge orchestration logic.
+
+## How the Subtasks Achieve This
+
+- **Orchestration mode — config, tab UI, worktree coupling**: Adds `'orchestration'` to the `automationMode` enum and its normalization (`autobanState.ts:275`), a config block (interval + any orchestration-specific settings paralleling `SingleColumnAutobanConfig`), the AUTOMATION-tab selector option and a **Start orchestrator** button (`src/webview/kanban.html` `createAutobanPanel`), and the coupling that flips `feature_worktree_mode` to per-feature when the mode is selected. Foundation for the rest.
+- **Kickoff — group + fan out**: On Start, launches the orchestrator terminal and runs `group-into-features` with the confirm gate off and a **`Miscellaneous`** leftover sweep so no plan is ungrouped; the system auto-creates worktrees + terminals; the orchestrator dispatches each feature's subtasks by stage, then sleeps. Depends on the mode foundation.
+- **Agent→orchestrator request channel + session log**: A file inbox convention (e.g. `.switchboard/orchestrator/inbox/…`) and a small agent skill that planners/reviewers/coders use to file a question, warning, or research request, plus the session log the orchestrator writes triage summaries to. The one genuinely new mechanic; the send path reuses "write a file," the read/verify path is the orchestrator's job on wake.
+- **Wake + triage loop (incl. feature-by-feature merge-back)**: On each interval tick the system wakes the orchestrator; it reads the inbox, **verifies against git/board state** (truth, not self-report), summarizes to the session log, and acts — advance stages, dispatch a research agent, escalate planner-stage questions to the human, and run the agent-driven merge-back per feature (subtask → integration → main, resolving conflicts). Depends on all of the above.
+- **Orchestrator persona workflow** (`.agents/workflows/orchestrator.md`): The agent definition the mode launches into the orchestrator terminal — its responsibilities, the wake/triage protocol, the "verify via git, never trust self-report" rule, the planner-escalation boundary, and the merge-back procedure. Cross-cuts the subtasks above; can be authored alongside the kickoff/triage work.
+
+## Dependencies & sequencing
+
+The mode foundation lands first (everything keys off the new `automationMode`). Kickoff (group + fan out) and the request-channel/session-log can proceed in parallel once the foundation exists. The wake+triage loop depends on both the channel and the fan-out being in place, and the merge-back step within it depends on the worktree topology from kickoff. The orchestrator persona workflow is authored across kickoff + triage since it encodes both behaviours.
+
+## Key design decisions (settled during planning)
+
+- **System-woken, not self-scheduling.** The orchestrator has no timer of its own; it relies entirely on the autoban interval tick to be re-invoked, re-hydrating state from git/board/inbox each wake. This is the durability strategy — no long-lived in-context fleet state to lose.
+- **Grouping confirm gate is OFF in this mode.** Unattended operation can't block on approval. Users who want to review/curate groupings do so manually *before* starting automation.
+- **`Miscellaneous` leftover feature.** The orchestrator's grouping differs from the interactive skill by sweeping all standalone plans into one `Miscellaneous` feature so the batch has no ungrouped remainder.
+- **Merge-back is in scope, feature by feature.** The orchestrator merges and resolves conflicts one feature at a time (subtask → integration → main), which keeps the conflict surface contained; it is not a bulk `git merge`.
+- **Ground truth over self-report.** Completion and progress are judged from git state (branch ahead of base, commits, tests) and board columns, not from an agent saying "done." Messaging/requests are for questions and nudges, not status of record.
+- **Planners stay human-in-the-loop.** Planner-stage questions/warnings are escalated to the human via the session log, not auto-resolved. Orchestration is coding + code-review automation.
+
+## Anchors / reuse map
+
+- Automation mode enum + normalization: `src/services/autobanState.ts:275` (`automationMode`), `SingleColumnAutobanConfig` as the config-shape template (`:18`).
+- AUTOMATION tab UI: `src/webview/kanban.html` `createAutobanPanel` (mode selector, per-mode config panels).
+- Grouping skill to invoke: `.agents/skills/group-into-features/SKILL.md` (SCAN → cluster → `create-feature.js`); confirm gate at step 4 is the thing this mode disables.
+- Feature/worktree ops via API: `src/services/LocalApiServer.ts` routes `/kanban/feature*`, `/kanban/move`, `/worktree/cleanup`.
+- Merge pattern to follow: the `merge-prompt-button` design (agent resolves conflicts in the worktree; kind-aware target subtask → integration → main).
+- Interval/wake substrate: autoban `intervalMinutes` + `lastTickAt` (`autobanState.ts` rules), and `PipelineOrchestrator`'s tick skeleton as reference.
+
+## Out of scope
+
+- The Notion command channel (natural-language directive in / status out) — a natural follow-on I/O layer on top of this engine, deliberately deferred. This feature is driven from the AUTOMATION tab.
+- Remote / Claude-Code-on-web operation — Orchestration is local-only (it needs the running extension, terminals, and worktrees).
+- Automating the planner stage — explicitly excluded; planning stays human-in-the-loop.
+- Any new scheduler — the orchestrator is woken by the existing autoban tick, not a new timer.
+
+<!-- BEGIN SUBTASKS (auto-generated, do not edit) -->
+<!-- END SUBTASKS -->

--- a/.switchboard/plans/orchestration-1-automation-mode-foundation.md
+++ b/.switchboard/plans/orchestration-1-automation-mode-foundation.md
@@ -1,0 +1,48 @@
+# Add an Orchestration Automation Mode (Config, AUTOMATION-Tab UI, Worktree-Mode Coupling)
+
+## Metadata
+**Complexity:** 6
+**Tags:** backend, frontend, ui, feature, automation
+**Project:** Switchboard
+
+## Goal
+
+Add a fourth kanban automation mode, **Orchestration**, as the foundation the rest of the feature builds on. This subtask adds the mode to the autoban state model, surfaces it in the AUTOMATION tab with a **Start orchestrator** control, and couples selecting the mode to enabling **worktree-per-feature**. No grouping, dispatch, or triage behaviour lands here — only the mode, its config, and its wiring.
+
+### Problem / background / root cause
+
+The autoban engine already carries a mode discriminator — `automationMode: 'single-column' | 'multi-column' | 'antigravity-batch'` on `AutobanConfigState` (`src/services/autobanState.ts:76`), defaulted and validated in `normalizeAutobanConfigState` (`:275`). The AUTOMATION tab renders per-mode config from `createAutobanPanel` in `src/webview/kanban.html`. Orchestration needs to be a first-class member of that same enum so it inherits persistence, normalization, broadcast, and the interval tick — rather than being bolted on as a parallel mechanism. Per-feature worktrees are the unit of parallelism and the merge topology for the whole feature, so selecting Orchestration must turn `feature_worktree_mode` on automatically instead of relying on the user to remember.
+
+## Detailed changes
+
+### 1. State model (`src/services/autobanState.ts`)
+
+- Extend the `automationMode` union on `AutobanConfigState` (`:76`) with `'orchestration'`, and add it to the validity list in `normalizeAutobanConfigState` (`:275`) so a persisted `'orchestration'` round-trips (unknown values still fall back to `'single-column'`).
+- Add an `OrchestrationConfig` type paralleling `SingleColumnAutobanConfig` (`:18`): at minimum `{ enabled: boolean; intervalMinutes: number }` (wake cadence; clamp 1–60 like the single-column normalizer), with room for later fields. Add `orchestrationConfig?: OrchestrationConfig` to `AutobanConfigState` and a `normalizeOrchestrationConfig` helper mirroring `normalizeSingleColumnConfig` (`:40`). Wire it into `normalizeAutobanConfigState`'s return and `buildAutobanBroadcastState` if it needs live fields.
+
+### 2. AUTOMATION tab UI (`src/webview/kanban.html`, `createAutobanPanel`)
+
+- Add an **Orchestration** option to the mode selector (`modeSelect`, guarded near `:7582`).
+- Render an orchestration config panel (shown when the mode is selected): the wake **interval** input and a **Start orchestrator** button, plus a status line (idle / running / last wake). Follow the existing per-mode panel pattern and the `guardInteraction` mechanism so config edits don't fight re-renders.
+- **Start orchestrator** posts a message (e.g. `{ type: 'startOrchestrator', workspaceRoot }`) to the backend. No `window.confirm()` anywhere (project hard rule — it is a silent no-op in the webview).
+
+### 3. Backend wiring (`src/services/KanbanProvider.ts`)
+
+- On mode change to `'orchestration'`, **enable `feature_worktree_mode` (per-feature)**, preserving the user's prior value so it can be restored when they switch away (store the previous setting in config; restore on mode-change-away). Adding this coupling here keeps subtask 4 (kickoff) able to assume worktrees exist.
+- Add a `startOrchestrator` message handler that launches the orchestrator terminal. The persona it runs is authored in subtask 2; here the handler only needs the launch hook (open/allocate the orchestrator terminal and inject its workflow prompt). If subtask 2 hasn't landed, this can dispatch a placeholder prompt so the wiring is testable.
+
+## Edge cases & constraints
+
+- **Old installs.** `normalizeAutobanConfigState` already defaults unknown modes to `'single-column'`, so a workspace on an older extension version that somehow receives `'orchestration'` degrades safely. Adding the value is backward-compatible (no schema migration).
+- **Worktree-mode coupling is reversible.** Selecting Orchestration must not silently destroy a user's chosen `feature_worktree_mode`; persist the prior value and restore on switch-away.
+- **No confirm dialogs** (project rule).
+
+## Testing
+
+- `normalizeAutobanConfigState` round-trips `'orchestration'` and its `orchestrationConfig`; unknown modes still fall back to `'single-column'`.
+- Selecting the mode in the UI flips `feature_worktree_mode` on; switching away restores the prior value.
+- **Start orchestrator** button posts the message and the backend allocates/launches the orchestrator terminal.
+
+## Out of scope
+
+- Grouping, fan-out, wake/triage, and merge-back (subtasks 3–5) and the orchestrator persona (subtask 2). This subtask is purely the mode, its config surface, and the worktree-mode coupling.

--- a/.switchboard/plans/orchestration-2-persona-workflow.md
+++ b/.switchboard/plans/orchestration-2-persona-workflow.md
@@ -1,0 +1,43 @@
+# Author the Orchestrator Persona Workflow (`.agents/workflows/orchestrator.md`)
+
+## Metadata
+**Complexity:** 5
+**Tags:** docs, backend, feature, automation
+**Project:** Switchboard
+
+## Goal
+
+Author the orchestrator agent's persona as a Switchboard workflow at `.agents/workflows/orchestrator.md`, and register it in the mirror manifest so it is discoverable as a skill. This is the agent that the Orchestration mode launches into the orchestrator terminal; it encodes the wake/triage protocol, the verify-via-git rule, the planner-escalation boundary, and the merge-back procedure that subtasks 4 and 5 rely on.
+
+### Problem / background / root cause
+
+Every role in Switchboard is defined by a workflow/skill file under `.agents/` (the single source of truth), which `ClaudeCodeMirrorService` mirrors into `.claude/skills/` for native discovery (`src/services/ClaudeCodeMirrorService.ts:46`, `MIRROR_MANIFEST`). The orchestrator must follow the same pattern rather than hard-coding behaviour in a prompt string, so its behaviour is versioned, editable, and consistent with `improve-plan`, `switchboard-chat`, etc. Subtasks 4 (kickoff) and 5 (wake/triage/merge) are the *engine*; this file is the *behaviour* those hooks invoke, so it must exist as a stable, referenceable artifact.
+
+## Content the workflow must specify
+
+- **Role & scope.** The orchestrator manages a batch through **coding and code review only**. It never automates planning; planner-stage questions escalate to the human.
+- **Kickoff protocol** (consumed by subtask 4): run `group-into-features` end-to-end **without the confirm gate**, then sweep all remaining standalone plans into a single **`Miscellaneous`** feature so nothing is ungrouped; ensure each feature has worktrees + terminals; dispatch each feature's subtasks by stage; then stop and sleep.
+- **Wake/triage protocol** (consumed by subtask 5): on each system wake, (1) read the request inbox, (2) **verify real progress from git and board state — never trust an agent's self-reported "done"**, (3) write a triage summary to the session log, (4) act: advance a stage, dispatch a research agent for a well-formed request, escalate planner-stage or unresolvable items to the human, or run merge-back for a completed feature.
+- **Verify-via-git rule.** Define the concrete signals: branch ahead of base, commits present, tests where applicable, card column. Self-report is a nudge, not status of record.
+- **Merge-back procedure.** Feature by feature, following the agent-driven merge pattern (subtask → feature integration branch → main), resolving conflicts as it goes; then request worktree cleanup. Never a bulk `git merge`.
+- **Escalation boundary.** Exactly what goes to the human (planner questions, unresolvable conflicts, stalled agents) vs. what the orchestrator handles itself.
+- **Comms.** How to read `.switchboard/orchestrator/inbox/` and append to `.switchboard/orchestrator/session-log.md` (defined in subtask 3).
+
+## Registration
+
+- Add an entry to `MIRROR_MANIFEST` in `ClaudeCodeMirrorService.ts` for `workflows/orchestrator.md` → skill name `orchestrator` (choose the appropriate invocation mode — likely `no-user`/model-launched, since the mode launches it rather than the user typing `/orchestrator`).
+- Add it to the skills/workflow tables in `CLAUDE.md`/`AGENTS.md` for discoverability, consistent with the other entries.
+
+## Edge cases & constraints
+
+- Keep the persona aligned with the "system-woken, not self-scheduling" decision — the workflow must not instruct the agent to set its own timers.
+- The workflow references file paths and skills defined in sibling subtasks; note the dependency so it is authored after (or alongside) subtask 3's inbox/log convention is fixed.
+
+## Testing
+
+- Mirror regeneration picks up the new workflow into `.claude/skills/orchestrator/SKILL.md` without touching user-authored skills.
+- A dry read of the workflow by an agent yields an unambiguous kickoff and wake/triage procedure (reviewed manually).
+
+## Out of scope
+
+- The engine hooks that launch and wake the orchestrator (subtasks 1, 4, 5) and the inbox/log implementation (subtask 3). This subtask is the persona document + its registration.

--- a/.switchboard/plans/orchestration-3-agent-request-channel-and-session-log.md
+++ b/.switchboard/plans/orchestration-3-agent-request-channel-and-session-log.md
@@ -1,0 +1,49 @@
+# Add a File-Based Agent→Orchestrator Request Channel and Session Log
+
+## Metadata
+**Complexity:** 5
+**Tags:** backend, feature, automation
+**Project:** Switchboard
+
+## Goal
+
+Add the one genuinely new mechanic in this feature: an asynchronous, file-based channel for coding/review agents to raise questions, warnings, and research requests to the orchestrator, plus an append-only **session log** the orchestrator writes its triage summaries to. This is what lets the orchestrator sleep between wakes and still coordinate a fleet — agents drop requests to files; the orchestrator drains them on wake.
+
+### Problem / background / root cause
+
+The orchestrator is system-woken and does not hold the fleet in-context, so it cannot receive synchronous messages from the agents it dispatched. Coding and (especially) review agents legitimately need to surface things mid-run — a warning, an ambiguous requirement, "I need to run research first." There is no inter-terminal messaging primitive in the local extension (the Antigravity `send_message` is not reachable here), and synchronous REPL scraping is fragile. A **file inbox** sidesteps all of that: writing a file is trivial for any agent, survives the orchestrator being asleep, and is inspectable by the human. A **session log** gives the run an auditable narrative and a place for the orchestrator to record what it did and what it escalated.
+
+## Detailed changes
+
+### 1. Inbox convention (`.switchboard/orchestrator/inbox/`)
+
+- One file per request, uniquely named (e.g. `<sortable-timestamp>-<agent-or-worktree>-<shortid>.md` or `.json`) so concurrent writers never collide.
+- Fields: `from` (agent/terminal/worktree), `stage` (planner|coder|reviewer), `type` (question|warning|research|blocked), `planId`/`feature`, `body`, and optional `worktreePath`.
+- Processed requests move to `inbox/processed/` (or gain a `handled` marker) so a wake never reprocesses them — mirrors the seen-set discipline used elsewhere for at-least-once handling.
+
+### 2. Agent skill to file a request (`.agents/skills/orchestrator_request/`)
+
+- A `SKILL.md` + a small shell script that writes a well-formed request file into the inbox (pure file write — no LocalApiServer dependency, so it works even if the API port file isn't found; optionally also offer an API path for consistency with other skills).
+- Document **when** agents should use it (a real blocker/question/research need — not routine progress) and the field contract.
+- Register in `CLAUDE.md`/`AGENTS.md` skills table and the mirror manifest if it should surface in `.claude/`.
+
+### 3. Session log (`.switchboard/orchestrator/session-log.md`)
+
+- Append-only markdown. The orchestrator writes a dated triage summary each wake: what it read, what it verified from git, what it advanced/dispatched/merged, and what it escalated to the human. Human-readable is the priority (this is the "what happened overnight" record).
+
+## Edge cases & constraints
+
+- **Directory bootstrap.** Create `.switchboard/orchestrator/inbox/` (and `processed/`) on first use; don't assume they exist.
+- **Concurrent writes.** Unique filenames per request; never a single shared file the agents append to.
+- **Idempotent drain.** Moving/marking processed must be safe to re-run if a wake is interrupted mid-drain.
+- **Do not gitignore blindly.** Decide whether the inbox/log are committed or local-only; the session log is useful history, the inbox is transient — document the choice.
+
+## Testing
+
+- The skill writes a valid, parseable request file with all required fields; concurrent invocations produce distinct files.
+- A simulated drain reads pending requests, moves them to `processed/`, and a second drain sees nothing.
+- Session-log appends are well-formed and ordered.
+
+## Out of scope
+
+- The orchestrator's *consumption* of the inbox and its triage decisions (subtask 5) — this subtask provides the channel and log; subtask 5 acts on them.

--- a/.switchboard/plans/orchestration-4-kickoff-group-and-fan-out.md
+++ b/.switchboard/plans/orchestration-4-kickoff-group-and-fan-out.md
@@ -1,0 +1,49 @@
+# Orchestration Kickoff — Auto-Group into Features (+ Miscellaneous) and Fan Out to Worktrees
+
+## Metadata
+**Complexity:** 7
+**Tags:** backend, feature, automation
+**Project:** Switchboard
+
+## Goal
+
+Implement what happens when the user presses **Start orchestrator**: the orchestrator batches all eligible plans into features (with the confirm gate off and a `Miscellaneous` sweep so nothing is left loose), the system auto-creates each feature's worktrees and terminals, and the orchestrator dispatches each feature's subtasks by stage, then goes to sleep.
+
+### Problem / background / root cause
+
+Grouping, worktree creation, and dispatch all exist as separate operations today, driven by a human. `group-into-features` (`.agents/skills/group-into-features/SKILL.md`) clusters loose plans but has a **load-bearing confirm gate** (step 4) that blocks unattended use, and it leaves genuinely standalone plans ungrouped by design. Worktree-per-feature creation and terminal provisioning already fire off feature/card operations. Kickoff's job is to sequence these into one unattended pass so a batch goes from "20 loose cards in Plan Reviewed" to "every card in a feature, worktrees up, coders dispatched" without a human clicking through each step.
+
+## Detailed changes
+
+### 1. Non-interactive grouping + `Miscellaneous` sweep
+
+- The orchestrator (via its persona, subtask 2) runs `group-into-features`' SCAN → READ → PROPOSE → EXECUTE **without CONFIRM** — the gate-off decision is intentional and documented in the feature (users who want to curate group manually before starting). Reuse `create-feature.js` / `assign-to-feature.js` exactly as the skill documents.
+- After real groups are created, **sweep all remaining standalone in-scope plans into a single `Miscellaneous` feature** so the batch has no ungrouped remainder. Handle the already-exists case (reuse the existing `Miscellaneous` feature and assign to it rather than creating duplicates).
+- Scope matches the skill: pre-coding columns (CREATED, PLAN REVIEWED), respecting any active project filter.
+
+### 2. Auto-create worktrees + terminals
+
+- With `feature_worktree_mode` per-feature already on (subtask 1), ensure each new feature gets its integration + subtask worktrees and their terminals via the existing worktree-creation path. Confirm the trigger fires for features created programmatically during kickoff (not only via manual UI creation) — wire it if the programmatic path doesn't already provision worktrees.
+
+### 3. Staged fan-out
+
+- The orchestrator advances each feature's subtasks into the coding stage by moving cards via the board operations (`/kanban/move`), letting the established per-column dispatch send the coder into the worktree terminal — i.e. the orchestrator drives the board the way a human does, rather than inventing a separate dispatch path. Confirm the coding-column dispatch delivers the agent into the correct per-feature worktree terminal.
+- After dispatching the batch, the orchestrator **stops and sleeps** — it does not poll. The system wakes it later (subtask 5).
+
+## Edge cases & constraints
+
+- **Empty / already-grouped board.** Nothing loose → no features created, `Miscellaneous` not created; kickoff is a clean no-op that still arms the wake loop.
+- **Plans already in a feature or a subtask** are skipped by the grouping scan (respect the `feature` / `subtask-of:` tags).
+- **Concurrency ceiling.** Fanning out N features × their subtasks must respect the existing terminal-pool / batch limits (`MAX_AUTOBAN_TERMINALS_PER_ROLE`, batch size) — don't spawn unbounded terminals. Document how many run at once and how the rest queue.
+- **`Miscellaneous` naming collision** across runs → reuse, don't duplicate.
+
+## Testing
+
+- With several loose plans across CREATED/PLAN REVIEWED, kickoff creates coherent features plus a `Miscellaneous` feature covering the leftovers; no plan is left ungrouped.
+- Each created feature has worktrees + terminals provisioned.
+- Subtasks are dispatched into their feature worktree terminals; the orchestrator then reports sleeping.
+- Empty board → clean no-op.
+
+## Out of scope
+
+- Wake, progress verification, triage, and merge-back (subtask 5). Kickoff ends at "dispatched and sleeping."

--- a/.switchboard/plans/orchestration-5-wake-triage-and-merge-back.md
+++ b/.switchboard/plans/orchestration-5-wake-triage-and-merge-back.md
@@ -1,0 +1,56 @@
+# Orchestration Wake + Triage Loop with Feature-by-Feature Merge-Back
+
+## Metadata
+**Complexity:** 8
+**Tags:** backend, feature, automation, reliability
+**Project:** Switchboard
+
+## Goal
+
+Close the loop: on each preconfigured interval, the *system* wakes the orchestrator; it drains the request inbox, verifies real progress against git and board state, writes a triage summary to the session log, and acts — advancing stages, dispatching research, escalating planner-stage or unresolvable items to the human, and merging completed features back (feature by feature, resolving conflicts). The batch ends when every feature is merged or escalated.
+
+### Problem / background / root cause
+
+Kickoff (subtask 4) leaves the fleet running and the orchestrator asleep. Something has to reconvene it, and the decision is explicit: **the system wakes it, not itself.** The autoban engine already ticks on `intervalMinutes` with `lastTickAt` tracking (`src/services/autobanState.ts`), which is exactly the heartbeat needed — in Orchestration mode the tick, instead of doing per-column dispatch, re-invokes the orchestrator with a "check status" wake. On wake the orchestrator must judge progress from **ground truth** (git branch ahead of base, commits, tests, card column) because an agent reporting "done" is unreliable; the inbox (subtask 3) carries the questions it must triage; and merge-back is the terminal action that retires each feature.
+
+## Detailed changes
+
+### 1. Wake hook (autoban tick, orchestration mode)
+
+- In the autoban tick path, when `automationMode === 'orchestration'`, replace per-column dispatch with an orchestrator **wake**: send the orchestrator terminal a "wake: check status" prompt. Reuse the existing `intervalMinutes` + `lastTickAt` machinery and the single-flight guard so overlapping wakes don't stack (mirror the `_polling` guard pattern used by `RemoteControlService._poll`).
+- Respect pause/stop: pausing the automation pauses wakes; stopping ends the loop.
+
+### 2. Triage (orchestrator behaviour, per subtask-2 persona)
+
+- **Drain inbox** (`.switchboard/orchestrator/inbox/`): for each request, decide an action by type — answer/act on a coder/reviewer question, dispatch a **research agent** for a well-formed research request, or **escalate** planner-stage questions and anything ambiguous/unresolvable to the human.
+- **Verify progress from git/board**, not self-report: a subtask counts as coded only when its worktree branch is ahead of base with committed work (and tests where applicable); reviewed only when the review stage genuinely passed. Advance cards via `/kanban/move` accordingly.
+- **Session log**: append a dated summary each wake — read, verified, advanced/dispatched/merged, escalated.
+- Move processed inbox items to `processed/`.
+
+### 3. Merge-back (feature by feature)
+
+- When all of a feature's subtasks are code-reviewed, the orchestrator performs the **agent-driven merge** following the `merge-prompt` pattern: subtask branches → the feature integration branch → main, **resolving conflicts as it goes** (never a bare `git merge` that dead-ends). Do one feature at a time to keep the conflict surface contained.
+- On success, request worktree cleanup via the existing `worktree_cleanup` skill / `/worktree/cleanup`. On a conflict the agent cannot resolve, leave the worktree intact and **escalate** to the human via the session log.
+
+### 4. Termination
+
+- When every feature is merged or escalated, the batch is done: write a final session-log summary and stop (or idle) the orchestration loop, mirroring how `PipelineOrchestrator` auto-stops when nothing is pending.
+
+## Edge cases & constraints
+
+- **Stalled agent.** No git progress across a configurable number of wakes → escalate rather than spin forever.
+- **Overlapping wakes.** Single-flight guard; a wake that arrives while the previous is still working is skipped (re-fires next tick).
+- **Partial feature.** Don't merge a feature until *all* its subtasks are reviewed; a half-done feature stays in progress.
+- **Planner escalation is a hard boundary** — planner-stage questions are never auto-answered.
+- **Verification beats optimism** — if git says no work landed, the subtask is not "done" regardless of what the agent wrote.
+
+## Testing
+
+- Simulated wake with git progress advances the right cards; without progress, nothing advances and a stall eventually escalates.
+- Inbox drain routes each request type correctly (act / research / escalate) and marks items processed.
+- A clean feature merges subtask → integration → main and triggers cleanup; an unresolvable conflict escalates and leaves the worktree.
+- Loop terminates and reports when all features are merged/escalated; overlapping wakes are single-flighted.
+
+## Out of scope
+
+- The Notion command channel (directive in / status out) — deferred per the feature doc. Wake is driven by the autoban interval, reported via the session log.


### PR DESCRIPTION
Plan the Orchestration kanban automation mode: a system-woken orchestrator
that batches work into features, fans out across per-feature worktrees, and
drives coding + code review to a feature-by-feature merge-back. Planning
stays human-in-the-loop.

Feature doc plus five subtask plans (mode foundation, persona workflow,
agent->orchestrator file request channel + session log, kickoff/group +
fan-out, wake/triage + merge-back).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RDYKrpMsJVmcZDNKjtH3xS