### PR TITLE
Add plan: remote content-pull for all providers

### DIFF
--- a/.switchboard/plans/cross-platform-agent-collaboration.md
+++ b/.switchboard/plans/cross-platform-agent-collaboration.md
@@ -1,0 +1,51 @@
+# Cross-platform agent collaboration (exploratory — phase 2 on content-pull)
+
+## Goal
+
+Explore and specify making Switchboard a coordination substrate where AI agents on **different platforms** (Linear, Notion, ClickUp, Claude Desktop, CLIs) collaborate on the **same plan** through the board — each driving a different column/role — with the board as the shared blackboard.
+
+### Problem Analysis (why this is now within reach)
+
+Switchboard is already structurally a **blackboard**: agents coordinate through shared artifacts, not direct messaging. Most of the substrate exists — an open roster (any agent), **file-based completion** (host-agnostic "done"), a **two-way comment bus**, and **columns that already encode a handoff protocol** (Planned → Coding → Review) with per-column role dispatch. The one missing piece was a shared, mutable *spec*: plan content only flowed outward. The **remote-content-pull-all-providers** plan closes that gap. Once the plan body syncs bidirectionally across providers, agents on different platforms can collaborate on one plan through the board with no direct integration between them — the elegant form being *"each column/role is driven by an agent on a different platform, and column transitions are the handoffs."*
+
+This is cross-**vendor** collaboration no single platform will ever build (their incentive is to keep you in their garden), which makes it structurally defensible — a moat made of competitors' incentives.
+
+## Dependencies
+
+**Hard dependency on `remote-content-pull-all-providers`** — a shared, bidirectional spec is the prerequisite. This is explicitly phase 2.
+
+## Metadata
+
+**Tags:** integrations, remote, architecture, exploratory
+**Complexity:** 7
+
+## User Review Required
+
+This is an exploratory/design plan. Approve the direction and the coordination-model choice before any implementation.
+
+## The real problem: coordination, not plumbing
+
+Emergent collaboration (implicit, through the shared plan + columns + comments) is nearly free once content-pull ships, and works when agents take turns naturally. Turning it into a deliberate feature needs coordination primitives:
+
+- **Turn-taking / soft locks** so two agents don't edit one plan simultaneously. This is exactly where content-pull's deferred "conflicts are rare, last-write-wins" model breaks: with concurrent collaborators, conflicts become the *normal* case, not the exception. The conflict model must be **pluggable** — last-write-wins today, lock/turn-token for collaboration.
+- **Attribution / provenance** — which platform/agent made each change. Partly present already (comment `authoredBySelf`, plan `sourceType`); needs extending to state and content changes.
+- **Handoff semantics** — formalize "column = whose turn / which role acts", allowing a column to be owned by a specific platform's agent.
+- **Presence** (optional) — which agents are active on a plan right now.
+
+## Proposed exploration
+
+1. **Prototype "different platforms own different columns":** a Linear agent owns Planning (deepens the spec → content-pull brings it local), the local CLI owns Coding, a Notion reviewer owns Review (comment bus carries feedback). Verify the round-trip end to end.
+2. **Design the pluggable conflict interface** (strategy: `last-write-wins | lock | turn-token`) plus a soft-lock mechanism keyed per plan.
+3. **Design attribution:** stamp each state/content/comment change with its originating platform/agent.
+4. **Decide the coordination surface:** columns-as-handoff vs. an explicit per-role assignment field.
+
+## Edge-Case & Dependency Audit
+- **Concurrency is the crux** — the whole feature stands on the conflict model. Ship content-pull with a *pluggable* conflict interface so this plan can add locking without a rewrite.
+- **Rate limits multiply** with more active agents/providers — reuse the per-provider pacing.
+- **ClickUp lacks the comment bus** — collaboration there is state/content-only, no conversation.
+
+### Repo
+switchboard (extension).
+
+## Definition of Done (for the exploration)
+A validated end-to-end demo of two different-platform agents collaborating on one plan via columns, plus a concrete design for the pluggable conflict model + attribution — ready to promote into an implementation plan.

--- a/.switchboard/plans/cross-platform-agent-collaboration.md
+++ b/.switchboard/plans/cross-platform-agent-collaboration.md
@@ -39,6 +39,17 @@ Emergent collaboration (implicit, through the shared plan + columns + comments) 
 3. **Design attribution:** stamp each state/content/comment change with its originating platform/agent.
 4. **Decide the coordination surface:** columns-as-handoff vs. an explicit per-role assignment field.
 
+## Prior art & integration targets
+
+The industry is building exactly this coordination layer — which validates the direction and gives concrete integration surfaces rather than only competitors:
+
+- **Notion Developer Platform — External Agents API** (May 2026). Notion's version of this: third-party agents (Claude, Codex, Cursor, Devin, etc.) join a workspace as first-class collaborators via webhook triggers + REST/MCP + per-resource permissions, running in Notion Workers or the vendor's cloud. It is the **hub/integration/cloud** realization — agents integrate *into Notion* to act on *Notion content*. Switchboard's differentiator is the inverse: **local + open + repo-centric**, no integration required. Two concrete ties:
+  - **Switchboard-as-external-agent:** register a Switchboard-orchestrated pipeline *as* a Notion external agent, so a Notion-native team assigns work in Notion and Switchboard executes it locally on the repo and reports back. This is the neutral-broker role — the collaboration feature reaching users who live in Notion.
+  - **Webhooks over polling:** the External Agents API is webhook-driven. Where an exposed endpoint is acceptable, Notion webhooks could replace the remote poll loop for lower latency (keep polling as the no-host default; see the remote-boards "you are the remote part" model).
+- **Linear agent SDK / AgentSession** and **ClickUp** offer analogous (if narrower) agent-participant models — same integration-required shape.
+
+The lesson for this plan: design the coordination surface so Switchboard can both **drive** external-platform agents and **appear as** one, rather than assuming Switchboard is always the top-level orchestrator.
+
 ## Edge-Case & Dependency Audit
 - **Concurrency is the crux** — the whole feature stands on the conflict model. Ship content-pull with a *pluggable* conflict interface so this plan can add locking without a rewrite.
 - **Rate limits multiply** with more active agents/providers — reuse the per-provider pacing.

--- a/.switchboard/plans/pixel-interchange-animation.md
+++ b/.switchboard/plans/pixel-interchange-animation.md
@@ -1,0 +1,46 @@
+# Interchange pipeline animation for the landing page
+
+## Goal
+
+Produce the animated pixel-art "interchange" clip for the switchboard-site landing page and wire it into the already-scaffolded slot, replacing the placeholder.
+
+### Problem Analysis
+
+The landing page's lead visual is the "Before the first line" interchange section, whose `.clip` slot currently shows only a placeholder ("ANIMATION — BEAM · BOARD · AGENT"). The slot is already wired for `data-webm`/`data-mp4` (with a reduced-motion fallback), but no asset exists yet. This clip carries the core "Switchboard connects the tools you already use" story and sits above the fold, so it's the single highest-value missing asset on the site.
+
+## Dependencies
+
+The landing slot scaffold already exists (the interchange `<section>` in `index.astro`; the `.clip` contract in `landing.js`; `.clip img/video` styling in `global.css`). Asset production is external (another model/tool).
+
+## Metadata
+
+**Tags:** design, frontend, marketing, asset
+**Complexity:** 2
+**Project:** switchboard site
+
+## User Review Required
+
+Approve the animation before it ships — this is a visual-taste call.
+
+## Proposed Changes
+
+### The animation — one continuous scene, seamless ~5–6s loop, action left → right
+1. **Left (intake):** a Claude avatar emits `.md` files; the Switchboard UFO pulls them up in a cyan tractor beam.
+2. **Center (board lights up):** each absorbed `.md` blinks in as a glowing cyan plan card on the kanban board, timed to the beam.
+3. **Right (pickup):** a Spy vs Spy–style agent dashes in from the right edge, grabs one glowing card, and runs back out.
+4. Loop resets (board dims, agent gone, Claude's stack replenished).
+
+### Style
+Chunky retro pixel art, `image-rendering: pixelated`. Dark background `#0b0f0f` → `#141818`; cyan `#00f2fe`/`#00e5ff` for the beam, card glows, and connective sparkle. Match existing characters for continuity: `public/assets/switchboard-ufo-detailed.svg` (UFO) and `public/assets/docs-kanban-spy-agent-detailed-v2.svg` (agent).
+
+### Output + wiring
+- **16:9**, `object-fit: cover` — keep the three zones clear of the extreme edges.
+- Deliver **`interchange.webm`** (VP9) + **`interchange.mp4`** (H.264), muted, seamless loop, 1280×720 or 1920×1080, few-hundred-KB webm.
+- A **static poster PNG** (same 16:9) showing all three zones, for the reduced-motion fallback.
+- Drop assets into `public/assets/clips/`; add `data-webm`/`data-mp4` to the interchange `.clip` in `index.astro` (a comment there marks the exact spot). Wire the poster if used.
+
+### Repo
+switchboard-site.
+
+## Definition of Done
+The animation plays in the interchange slot; the poster shows under reduced-motion; the site build stays green; assets live in `public/assets/clips/`.

--- a/.switchboard/plans/remote-content-pull-all-providers.md
+++ b/.switchboard/plans/remote-content-pull-all-providers.md
@@ -90,12 +90,27 @@ Two product decisions are baked into this plan as defaults; flag them for confir
 **Files: setup/remote settings (`SetupPanelProvider.ts` / kanban remote config), `src/webview/setup.html`**
 - Add "Poll content from remote" toggle beside "Poll comments from remote"; persist in the Kanban DB like the other remote flags. No `settings.json`.
 
-### Phase 5 — Tests + docs
+### Phase 5 — Tests
 - Unit: ClickUp/Notion `fetchStateDeltas` populate `updatedAt` (+ ClickUp `description`); Notion `fetchDescription` renders body; seed-on-first-poll pulls nothing; echo guard no-ops an own-push round-trip (esp. lossy Notion); last-write-wins on genuine divergence. Extend `src/test/integrations/notion/*` and add a ClickUp equivalent.
-- Docs (switchboard-site, separate repo/branch): `integrations/remote-boards.md` currently calls Notion "Full two-way" and lists only "Poll comments from remote" — update the provider table and options to reflect content-pull, and note last-write-wins.
+
+### Phase 6 — Docs (REQUIRED — do not skip; cross-repo)
+
+**This lands in the `switchboard-site` repo, on the same branch name.** Edit `src/pages/docs/integrations/remote-boards.md` — the coder must make these exact edits as part of this change:
+
+1. **Provider table (`## Choosing a provider`, ~L21–25).** The "Full two-way" claims were only ever true for *state + comments* — content was push-only. Make them accurate now that content pulls back:
+   - **Linear** row — after "mirror, dispatch, comments, and push", add that **plan content now syncs both ways** (remote body edits pull back, last-write-wins).
+   - **Notion** row — same addition: content is now bidirectional, not just state + comments.
+   - **ClickUp** row — it currently says "Two-way for card state"; extend to note **content also syncs both ways** now (it still lacks the comment bus — keep that caveat).
+2. **Options section (`### Options`, ~L38–43).** Add a new bullet beside "Poll comments from remote":
+   - **Poll content from remote** — ingest remote edits to a plan's body and write them to the local plan file (last-write-wins; off by default until seeded to "now" on first enable).
+3. **Add a one-line conflict note** under the options: content sync is **last-write-wins by timestamp** — whichever side edited more recently wins; concurrent edits are assumed rare.
+4. **DO NOT change L58** ("Switchboard is the source of truth: remote edits to the **context page** are overwritten"). That's the Project Context page (PRDs/constitution/dev docs), which stays push-only — it is a *different* thing from plan content. Leave it exactly as is.
+
+Match the final toggle name and default to whatever Phase 4 actually ships, so the doc matches the UI.
 
 ## Definition of Done
 - Editing an existing plan's body in Notion or ClickUp updates the local plan file within one poll cycle, on par with Linear.
 - Enabling the feature on an existing remote does not retroactively overwrite local plans (seed-on-first-poll verified).
 - No pull↔push loop on any provider, including Notion's lossy round-trip.
 - Linear behaviour unchanged; all existing remote tests green.
+- **`switchboard-site` `remote-boards.md` updated per Phase 6** (provider table + "Poll content from remote" option + last-write-wins note; context-page line untouched), committed on the same branch.

--- a/.switchboard/plans/remote-content-pull-all-providers.md
+++ b/.switchboard/plans/remote-content-pull-all-providers.md
@@ -1,0 +1,100 @@
+# Remote content-pull for all providers (Notion, ClickUp) — not just Linear
+
+## Goal
+
+Make plan **content** (the plan body/description) sync *back* from remote boards to the local plan file for **every** remote provider — Notion and ClickUp — the way it already does for Linear. Today a plan's content is effectively one-way after creation: it is pushed out to the remote, and pulled *in* only once (when a brand-new remote card is first imported). Edits made to an existing plan's body on the remote never return, and an outbound content push can silently overwrite them.
+
+### Problem Analysis (background + root cause)
+
+**Why this matters now.** The remote system was designed when the remote surface was a place a *human* moved cards and left comments — the plan text was authored locally and mirrored out, so one-way content was fine. Since then the SaaS boards (Linear, Notion, ClickUp) shipped their own AI agents that can *rewrite a plan body in place*. A remote agent that deepens a plan's spec now has nowhere for that work to land: the extension never reads it back.
+
+**Root cause — it's a gate, not a missing feature.** The content-pull mechanism already exists and is complete:
+
+- `RemoteControlService._pollDescriptions()` (`src/services/RemoteControlService.ts`, ~L594–675) is a full, correct implementation: a per-issue description cursor (`remote.descriptionCursor.${kind}`), sha256 hash-based loop prevention, an empty-body guard ("never clobber with empty"), a 100 KB size guard, and H1-title preservation when rewriting the file.
+- It is invoked every poll from `_poll()` (~L312), right after `_pollState` and `_pollComments`.
+- The dependency wiring in `KanbanProvider.ts` (`getDescriptionCursors`/`setDescriptionCursor` ~L1966–1980, `onDescriptionPulled` hash registration ~L2007) is already **kind-generic** — it takes a `RemoteProviderKind` argument.
+
+Two things restrict it to Linear:
+
+1. **A hard gate:** `_pollDescriptions` returns early with `if (provider.kind !== 'linear') { return; }` (~L601).
+2. **Provider data:** the method reads `d.description` and `d.updatedAt` off the state deltas, and **only `LinearRemoteProvider.fetchStateDeltas` populates them** (`LinearRemoteProvider.ts` ~L54–79: the GraphQL query selects `description` + `updatedAt` inline). `NotionRemoteProvider.fetchStateDeltas` sets neither (`NotionRemoteProvider.ts` ~L98–117 — only `remoteId`, `stateKey`, `parentRemoteId`, `isFeatureCandidate`); ClickUp likewise.
+
+So the work is **generalizing an existing feature to two more providers**, not building content-pull from scratch. The subtlety is entirely in *how each provider supplies the body* and in not re-introducing echo loops or mass-overwrites.
+
+## Dependencies
+
+None blocking. Builds on the existing `_pollDescriptions` machinery and the per-kind cursor/hash wiring already in `KanbanProvider.ts`. Should land after any in-flight remote-sync work to avoid churn in `RemoteControlService.ts`.
+
+## Metadata
+
+**Tags:** backend, integrations, remote, notion, clickup, sync
+**Complexity:** 6
+
+## User Review Required
+
+Two product decisions are baked into this plan as defaults; flag them for confirmation:
+
+1. **Conflict resolution = last-write-wins by timestamp**, no merge dialog. The owner has stated conflicts are expected to be rare and acceptable. The existing hash check already prevents *no-op* clobbers; a genuine divergence resolves in favour of whichever side changed more recently (remote pull overwrites local only when the remote's `updatedAt`/`last_edited_time` is newer than the per-issue cursor). No 3-way UI in this plan.
+2. **Gating:** content-pull rides the existing **Full** remote mode plus a new **"Poll content from remote"** toggle (parallel to the existing "Poll comments from remote"), default **on** for new setups. Alternative: no toggle, always-on in Full mode. Recommend the toggle for symmetry and an escape hatch.
+
+## Complexity Audit
+
+### Routine
+- Remove the `provider.kind !== 'linear'` gate in `_pollDescriptions`.
+- Populate `updatedAt` on Notion state deltas (the value is already in hand as `row.last_edited_time`).
+- Populate `description` + `updatedAt` on ClickUp state deltas (task payload already carries `description`/`text_content` and `date_updated`).
+- Add the "Poll content from remote" setting + Setup Panel checkbox, mirroring the comments toggle.
+
+### Complex / Risky
+- **Notion body fetch is not a single field.** A Notion page body must be assembled via `fetchBlocksRecursive` + `convertBlocksToMarkdown` (one+ extra API call per page). Inlining that into `fetchStateDeltas` would fetch every changed page's blocks on every poll. Introduce a **lazy** provider method `fetchDescription(remoteId)` that `_pollDescriptions` calls *only* for rows whose `updatedAt` is past that issue's description cursor.
+- **Notion round-trip fidelity → loop risk.** `markdown → Notion blocks → markdown` is lossy, so the sha256 echo guard (which compares the re-rendered pull against local file content) can mismatch even when nothing meaningfully changed, causing a pull↔push ping-pong. Mitigation: compare against the **hash registered at push time** via the existing `onDescriptionPulled` loop-prevention registry (register the pushed content's hash on `pushContent`, not only on pull), rather than trusting a byte-identical re-render.
+
+## Edge-Case & Dependency Audit
+
+### Race conditions / data-loss
+- **First-enable mass overwrite.** When content-pull turns on for an existing Notion/ClickUp remote, there is no description cursor yet. It MUST **seed-on-first-poll to "now"** (no history replay), exactly as the state and comment cursors already do (`_pollState`/`_pollComments` baseline when `!cursor`). Without this, the first poll would overwrite every local plan with the remote body. This is the single most dangerous edge case.
+- **Concurrent local agent write.** Plan files are "write-once-at-the-end" by the coding agent. A remote pull mid-run could overwrite an agent's fresh write (or vice-versa). Accepted as rare per the owner; last-write-wins. The empty-body guard already prevents wiping a plan with a blank remote.
+- **Echo guard on our own push.** `pushContent` bumps the remote `updatedAt`/`last_edited_time`; the next poll must not treat that as an inbound edit. Handled by registering the pushed hash (see Complex section) + the existing `newHash === existingHash → skip + advance cursor` branch.
+
+### Rate limits / cost
+- Notion: bound block-fetches to genuinely-changed pages via the lazy `fetchDescription` + per-issue cursor check; respect the existing `LIMITER_MS` pacing in `NotionRemoteProvider`.
+- ClickUp: description arrives with the task query already used for state — no extra call.
+
+### Dependencies & conflicts
+- `RemoteStateDelta` (`RemoteProvider.ts` ~L19) already carries optional `description?`/`updatedAt?` (Linear populates them) — no type change needed for the inline path; add `fetchDescription?(remoteId)` as an optional interface method for the lazy path.
+- Cursor storage reuses `db.getConfig`/`setConfig` under `remote.descriptionCursor.${kind}` — new keys, unreleased for notion/clickup, so **no migration required** (clean addition).
+- ClickUp lacks the comment bus but that is orthogonal; content-pull is independent of comments.
+
+## Proposed Changes
+
+### Phase 1 — Ungate the poller, keep Linear green
+**File: `src/services/RemoteControlService.ts`**
+- Remove `if (provider.kind !== 'linear') { return; }` from `_pollDescriptions`.
+- Replace the "read `d.description` off the delta" assumption with a resolver: use `d.description` when present (Linear/ClickUp inline path); otherwise, if `provider.fetchDescription` exists, call it lazily for rows where `d.updatedAt > cursors[d.remoteId]`.
+- Add **seed-on-first-poll**: when a provider has no `remote.descriptionCursor.${kind}` entry set at all, baseline every current row's cursor to its `updatedAt` (or "now") and pull nothing this cycle.
+- Gate the whole method on the new "Poll content from remote" setting.
+- Regression check: Linear path must behave identically (inline description, existing tests pass).
+
+### Phase 2 — ClickUp inline description
+**File: `src/services/remote/ClickUpRemoteProvider.ts`**
+- In `fetchStateDeltas`, set `description` (task `description`/`text_content`) and `updatedAt` (`date_updated`, normalized to the same ISO/string form the cursor comparison expects) on each delta. No new fetch call.
+
+### Phase 3 — Notion lazy fetchDescription + fidelity guard
+**Files: `src/services/remote/NotionRemoteProvider.ts`, `src/services/RemoteControlService.ts`, `src/services/KanbanProvider.ts`**
+- Set `updatedAt` on Notion state deltas from `row.last_edited_time` (already read for `nextCursor`).
+- Add `fetchDescription(remoteId)` using the existing `fetchPageTitle` + `fetchBlocksRecursive` + `convertBlocksToMarkdown` path (the same one `importRemotePlan` uses at ~L415–417), returning `{ body, updatedAt }`.
+- On `pushContent`, register the pushed content's sha256 in the loop-prevention registry (extend the `onDescriptionPulled` mechanism, or add a sibling `onContentPushed`) so the pull comparison in `_pollDescriptions` uses the pushed hash and doesn't ping-pong on lossy re-render.
+
+### Phase 4 — Setting + UI
+**Files: setup/remote settings (`SetupPanelProvider.ts` / kanban remote config), `src/webview/setup.html`**
+- Add "Poll content from remote" toggle beside "Poll comments from remote"; persist in the Kanban DB like the other remote flags. No `settings.json`.
+
+### Phase 5 — Tests + docs
+- Unit: ClickUp/Notion `fetchStateDeltas` populate `updatedAt` (+ ClickUp `description`); Notion `fetchDescription` renders body; seed-on-first-poll pulls nothing; echo guard no-ops an own-push round-trip (esp. lossy Notion); last-write-wins on genuine divergence. Extend `src/test/integrations/notion/*` and add a ClickUp equivalent.
+- Docs (switchboard-site, separate repo/branch): `integrations/remote-boards.md` currently calls Notion "Full two-way" and lists only "Poll comments from remote" — update the provider table and options to reflect content-pull, and note last-write-wins.
+
+## Definition of Done
+- Editing an existing plan's body in Notion or ClickUp updates the local plan file within one poll cycle, on par with Linear.
+- Enabling the feature on an existing remote does not retroactively overwrite local plans (seed-on-first-poll verified).
+- No pull↔push loop on any provider, including Notion's lossy round-trip.
+- Linear behaviour unchanged; all existing remote tests green.

--- a/.switchboard/plans/remote-content-pull-all-providers.md
+++ b/.switchboard/plans/remote-content-pull-all-providers.md
@@ -83,6 +83,7 @@ Two product decisions are baked into this plan as defaults; flag them for confir
 **Files: `src/services/remote/NotionRemoteProvider.ts`, `src/services/RemoteControlService.ts`, `src/services/KanbanProvider.ts`**
 - Set `updatedAt` on Notion state deltas from `row.last_edited_time` (already read for `nextCursor`).
 - Add `fetchDescription(remoteId)` using the existing `fetchPageTitle` + `fetchBlocksRecursive` + `convertBlocksToMarkdown` path (the same one `importRemotePlan` uses at ~L415–417), returning `{ body, updatedAt }`.
+- **Preferred, if available:** evaluate Notion's **Markdown API** (Developer Platform, 2026 — read/write pages as markdown directly) in place of the block-fetch + `convertBlocksToMarkdown` round-trip. Reading the body as markdown natively is cleaner and likely sidesteps the lossy block round-trip that drives the ping-pong risk below. Weigh availability/token cost against the existing block path before committing.
 - On `pushContent`, register the pushed content's sha256 in the loop-prevention registry (extend the `onDescriptionPulled` mechanism, or add a sibling `onContentPushed`) so the pull comparison in `_pollDescriptions` uses the pushed hash and doesn't ping-pong on lossy re-render.
 
 ### Phase 4 — Setting + UI

--- a/.switchboard/plans/remote-content-pull-all-providers.md
+++ b/.switchboard/plans/remote-content-pull-all-providers.md
@@ -34,7 +34,7 @@ None blocking. Builds on the existing `_pollDescriptions` machinery and the per-
 
 Two product decisions are baked into this plan as defaults; flag them for confirmation:
 
-1. **Conflict resolution = last-write-wins by timestamp**, no merge dialog. The owner has stated conflicts are expected to be rare and acceptable. The existing hash check already prevents *no-op* clobbers; a genuine divergence resolves in favour of whichever side changed more recently (remote pull overwrites local only when the remote's `updatedAt`/`last_edited_time` is newer than the per-issue cursor). No 3-way UI in this plan.
+1. **Conflict resolution = last-write-wins by timestamp**, no merge dialog. The owner has stated conflicts are expected to be rare and acceptable. The existing hash check already prevents *no-op* clobbers; a genuine divergence resolves in favour of whichever side changed more recently (remote pull overwrites local only when the remote's `updatedAt`/`last_edited_time` is newer than the per-issue cursor). No 3-way UI in this plan. **Forward-compatibility:** implement the resolution as a *pluggable strategy* (last-write-wins now) rather than hard-coded — the follow-on `cross-platform-agent-collaboration` plan will add locking/turn-taking, and shouldn't require ripping this out. Concurrent edits are rare for one remote human but become the *normal* case once multiple agents collaborate on one plan.
 2. **Gating:** content-pull rides the existing **Full** remote mode plus a new **"Poll content from remote"** toggle (parallel to the existing "Poll comments from remote"), default **on** for new setups. Alternative: no toggle, always-on in Full mode. Recommend the toggle for symmetry and an escape hatch.
 
 ## Complexity Audit

--- a/.switchboard/plans/retire-bundled-docs-redirect-to-online.md
+++ b/.switchboard/plans/retire-bundled-docs-redirect-to-online.md
@@ -1,0 +1,55 @@
+# Retire the bundled user manual/guide; redirect docs affordances to the online site
+
+## Goal
+
+Delete the outdated bundled docs (`docs/switchboard_user_manual.md`, `docs/how_to_use_switchboard.md`) and repoint every "open docs" / "tutorial" affordance in the extension to the online documentation site, so there is a single source of truth.
+
+### Problem Analysis
+
+The extension ships two local markdown docs that have drifted stale now that the canonical documentation lives online at `https://tentacleopera.github.io/switchboard-site/docs/`. Several UI affordances still point at the local manual:
+
+- **`SetupPanelProvider._openDocs()`** (`src/services/SetupPanelProvider.ts` ~L1555) opens `docs/switchboard_user_manual.md` in a markdown preview, falling back to `README.md`.
+- **setup.html "Switchboard guide"** section (L585–588) has a **COPY TUTORIAL PROMPT** button whose handler (L3444–3455) builds a prompt instructing the agent to read `docs/switchboard_user_manual.md` (sections 2/3/5).
+- **setup.html `btn-open-docs`** (L3466) → posts an `openDocs` message.
+- **`TaskViewerProvider`** also handles an `openDocs` case (~L11289) — confirm and repoint.
+
+Leaving these pointed at soon-deleted/stale files gives users wrong or missing guidance.
+
+## Dependencies
+
+Pairs with the README-rewrite plan (`_openDocs`'s README fallback and the online site are the replacement targets). Land together or after it.
+
+## Metadata
+
+**Tags:** docs, cleanup, frontend, backend
+**Complexity:** 3
+
+## User Review Required
+
+Confirm the `how_to_plan.md` reference in **implementation.html L3309–3310** is **out of scope**. That prompt tells the *planner agent* to read `.agents/rules/how_to_plan.md` (the internal planning framework) — it is not a user tutorial, and `how_to_plan.md` is not being deleted. Default: leave it untouched.
+
+## Proposed Changes
+
+### Step 0 — Discovery (do first)
+Grep both webviews **and** their providers for every reference to the two deleted basenames, plus "tutorial", "guide", "manual", and "openDocs". List them all before editing so none is missed.
+
+### Delete
+- `docs/switchboard_user_manual.md`
+- `docs/how_to_use_switchboard.md`
+
+### Redirect `openDocs` → online site
+- `SetupPanelProvider._openDocs()`: replace the local-manual preview + README fallback with an external open — `vscode.env.openExternal(vscode.Uri.parse('https://tentacleopera.github.io/switchboard-site/docs/getting-started/installation'))` (or the docs root). Remove the now-dead stat/preview logic.
+- `TaskViewerProvider` `openDocs` case (~L11289): point to the same online docs URL.
+
+### Redirect the tutorial prompt
+- setup.html COPY TUTORIAL PROMPT handler (L3445): rewrite the copied prompt to reference the online docs instead of the local manual — e.g. *"Read the Switchboard docs at https://tentacleopera.github.io/switchboard-site/docs/getting-started/ (Installation, Agents, Planning) and walk me through setup as a numbered list; ask which step I want help with first."* Keep the button label.
+
+### Repo
+switchboard (extension).
+
+## Edge-Case & Dependency Audit
+- **Published extension / migrations:** these docs are shipped, but they are read-only *reference content* — deleting them is a clean break for the feature (no user data at risk). The only runtime dependency is `_openDocs`'s `stat` check; replacing it removes the dependency. No data migration needed.
+- **Offline users:** external-URL docs need a browser/network. Acceptable now that the site is canonical. Optionally keep a single README pointer line as a last-resort offline fallback (coordinate with the README plan).
+
+## Definition of Done
+Both files gone; every open-docs/tutorial affordance opens or references the online site; no dangling references to the deleted files anywhere in `src/`; extension compiles.

--- a/.switchboard/plans/retire-bundled-docs-redirect-to-online.md
+++ b/.switchboard/plans/retire-bundled-docs-redirect-to-online.md
@@ -24,9 +24,13 @@ Pairs with the README-rewrite plan (`_openDocs`'s README fallback and the online
 **Tags:** docs, cleanup, frontend, backend
 **Complexity:** 3
 
+## Non-Goals / Hard Constraints
+
+- **DO NOT delete or modify `.agents/rules/how_to_plan.md`, and DO NOT touch the reference to it in implementation.html (L3309–3310).** That prompt tells the *planner agent* to read the internal planning framework — it is not a user tutorial and is explicitly out of scope. Only the two user-facing docs named in "Delete" below are removed. If discovery surfaces other `how_to_plan.md` references, leave every one of them untouched.
+
 ## User Review Required
 
-Confirm the `how_to_plan.md` reference in **implementation.html L3309–3310** is **out of scope**. That prompt tells the *planner agent* to read `.agents/rules/how_to_plan.md` (the internal planning framework) — it is not a user tutorial, and `how_to_plan.md` is not being deleted. Default: leave it untouched.
+None — the scope is fixed above. (Only the two bundled user-facing docs are deleted; `how_to_plan.md` and all planning-framework references stay.)
 
 ## Proposed Changes
 

--- a/.switchboard/plans/rewrite-readme-match-online-docs.md
+++ b/.switchboard/plans/rewrite-readme-match-online-docs.md
@@ -1,0 +1,39 @@
+# Rewrite README to match the online docs
+
+## Goal
+
+Replace the drifted `README.md` with a concise README whose framing, positioning, and structure match the online documentation site, and which links out to it as the canonical reference instead of duplicating it.
+
+### Problem Analysis
+
+`README.md` predates the current positioning captured on the docs site — the 0→1 arc (research → plan → design → code → review), the open roster / Copy Prompt story, the project → feature → plan hierarchy, and remote boards. It's now a third, stale source of truth alongside the (soon-deleted) bundled manual and the online docs. A README should orient a GitHub visitor and funnel them to the online docs, not re-document the product.
+
+## Dependencies
+
+Pairs with the docs-retirement plan (after it, the README is the single in-repo doc, and may serve as `_openDocs`'s offline fallback). Use the online docs (`switchboard-site/src/pages/docs`) as the source of framing so the two stay consistent.
+
+## Metadata
+
+**Tags:** docs, marketing, cleanup
+**Complexity:** 3
+
+## User Review Required
+
+Approve the README voice/positioning — it's the repo's front door.
+
+## Proposed Changes
+
+- Rewrite `README.md` to mirror the online docs' framing:
+  - one-line pitch (run the whole build 0→1, concept to shipped);
+  - the arc (research → plan → design → code → review, kept legible on one board);
+  - the core differentiators, matching the site: a project model (not a task list), the move is the dispatch, works with anything (Copy Prompt / open roster), before-the-first-line interchange;
+  - install (`npx switchboard` for the browser board + the VS Code extension);
+  - a prominent **Full documentation → https://tentacleopera.github.io/switchboard-site/** link.
+- Keep it short: **orient + link, don't duplicate.** Pull section headings/wording from `switchboard-site/src/pages/docs` so the README and site read as one voice.
+- Remove any references to the deleted bundled manual. If the docs-retirement plan keeps a README offline fallback, make sure the README stands on its own for that purpose.
+
+### Repo
+switchboard (extension). Cross-reference: switchboard-site docs for framing.
+
+## Definition of Done
+README reflects current positioning, links to the online docs as canonical, contains no references to the deleted bundled manual, and reads consistently with the site.


### PR DESCRIPTION
Generalize the existing Linear-only _pollDescriptions content sync to Notion
and ClickUp. Documents that content-pull is already fully built (per-issue
cursors, hash loop-prevention, guards) but gated to Linear, and scopes the
provider work, the Notion round-trip/rate-limit risks, seed-on-first-poll
safety, and last-write-wins conflict handling.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>